### PR TITLE
Fix different types for x and y

### DIFF
--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -15,11 +15,11 @@ end
 
 # Dispatch aware of eltype(x) != eltype(prob.u0)
 function BVPSystem(prob::BVProblem, x, order)
-    Y = eltype(prob.u0)
+    T = eltype(prob.u0)
     M = length(prob.u0)
     N = size(x,1)
-    y = vector_alloc(Y, M, N)
-    BVPSystem(order, M, N, prob.f, prob.bc, prob.p, x, y, vector_alloc(Y, M, N), vector_alloc(Y, M, N), typeof(x)(undef,M))
+    y = vector_alloc(T, M, N)
+    BVPSystem(order, M, N, prob.f, prob.bc, prob.p, x, y, vector_alloc(T, M, N), vector_alloc(T, M, N), typeof(x)(undef,M))
 end
 
 # Auxiliary functions for evaluation

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -10,16 +10,16 @@ end
 function BVPSystem(fun, bc, p, x, y, order)
     T, U = eltype(x), eltype(y)
     M, N = size(y)
-    BVPSystem{T,U}(order, M, N, fun, bc, p, x, y, vector_alloc(U, M, N), vector_alloc(U, M, N), typeof(x)(M))
+    BVPSystem{T,U}(order, M, N, fun, bc, p, x, y, vector_alloc(T, M, N), vector_alloc(T, M,  N), eltype(y)(M))
 end
 
 # Dispatch aware of eltype(x) != eltype(prob.u0)
 function BVPSystem(prob::BVProblem, x, order)
-    U = eltype(prob.u0)
+    Y = eltype(prob.u0)
     M = length(prob.u0)
     N = size(x,1)
-    y = vector_alloc(U, M, N)
-    BVPSystem(order, M, N, prob.f, prob.bc, prob.p, x, y, vector_alloc(U, M, N), vector_alloc(U, M, N), typeof(x)(undef,M))
+    y = vector_alloc(Y, M, N)
+    BVPSystem(order, M, N, prob.f, prob.bc, prob.p, x, y, vector_alloc(Y, M, N), vector_alloc(Y, M, N), typeof(x)(undef,M))
 end
 
 # Auxiliary functions for evaluation

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -10,7 +10,15 @@ end
 function BVPSystem(fun, bc, p, x, y, order)
     T, U = eltype(x), eltype(y)
     M, N = size(y)
-    BVPSystem{T,U}(order, M, N, fun, bc, p, x, y, vector_alloc(T, M, N), vector_alloc(T, M, N), eltype(y)(M))
+    BVPSystem{T,U}(order, M, N, fun, bc, p, x, y, vector_alloc(U, M, N), vector_alloc(U, M, N), typeof(x)(M))
+end
+
+function BVPSystem(prob::BVProblem, x, order)
+    U = eltype(prob.u0)
+    M = length(prob.u0)
+    N = size(x,1)
+    y = vector_alloc(U, M, N)
+    BVPSystem(order, M, N, prob.f, prob.bc, prob.p, x, y, vector_alloc(U, M, N), vector_alloc(U, M, N), typeof(x)(undef,M))
 end
 
 # Auxiliary functions for evaluation

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -29,7 +29,7 @@ function DiffEqBase.__solve(prob::BVProblem, alg::Union{GeneralMIRK,MIRK}; dt=0.
     end
     n = Int(cld((prob.tspan[2]-prob.tspan[1]),dt))
     x = collect(range(prob.tspan[1], stop=prob.tspan[2], length=n+1))
-    S = BVPSystem(prob.f, prob.bc, prob.p, x, length(prob.u0), alg_order(alg))
+    S = BVPSystem(prob, x, alg_order(alg))
     if isa(prob.u0, AbstractVector{<:Number})
         copyto!.(S.y, (prob.u0,))
     elseif isa(prob.u0, AbstractVector{<:AbstractArray})

--- a/test/shooting_tests.jl
+++ b/test/shooting_tests.jl
@@ -22,3 +22,11 @@ resid_f = Array{Float64}(undef, 2)
 sol = solve(bvp, Shooting(Tsit5()))
 bc!(resid_f, sol, nothing, sol.t)
 @test norm(resid_f) < 1e-7
+
+#Test for complex values
+u0 = [0.,1.].+1im
+bvp = BVProblem(f, bc!, u0, tspan)
+resid_f = Array{ComplexF64}(undef, 2)
+sol = solve(bvp, Shooting(Tsit5()))
+bc!(resid_f, sol, nothing, sol.t)
+@test norm(resid_f) < 1e-7


### PR DESCRIPTION
Proposal to fix error for complex valued u0 as mentioned in [Discourse](https://discourse.julialang.org/t/can-we-solve-complex-valued-two-point-boundary-value-problems/53232).
Removed the `tmp` from `mutable struct BVPSystem` because it  was never used.