### PR TITLE
refactor: Fix MIRKTableau and MIRKInterpTableau

### DIFF
--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -8,40 +8,56 @@ import ForwardDiff, BandedMatrices, FiniteDiff
 
 import TruncatedStacktraces: @truncate_stacktrace
 
-struct MIRKTableau{T, cType, vType, bType, xType, sType, starType, tauType}
+struct MIRKTableau{sType, cType, vType, bType, xType}
+    """Discrete stages of MIRK formula"""
+    s::sType
     c::cType
     v::vType
     b::bType
     x::xType
-    """Discrete stages of MIRK formula"""
-    s::sType
-    """Number of stages to form the interpolant"""
-    s_star::starType
-    """Defect sampling point"""
-    tau::tauType
 end
 
-function MIRKTableau(c, v, b, x, s, s_star, tau)
-    @assert eltype(c) == eltype(v) == eltype(b) == eltype(x) == eltype(tau)
+function MIRKTableau(s, c, v, b, x)
+    @assert eltype(c) == eltype(v) == eltype(b) == eltype(x)
     return MIRKTableau{
-        eltype(c),
+        typeof(s),
         typeof(c),
         typeof(v),
         typeof(b),
         typeof(x),
-        typeof(s),
-        typeof(s_star),
-        typeof(tau),
-    }(c,
+    }(s,
+        c,
         v,
         b,
-        x,
-        s,
-        s_star,
-        tau)
+        x)
 end
 
 @truncate_stacktrace MIRKTableau 1
+
+struct MIRKInterpTableau{s, c, v, x, τ}
+    s_star::s
+    c_star::c
+    v_star::v
+    x_star::x
+    τ_star::τ
+end
+
+function MIRKInterpTableau(s_star, c_star, v_star, x_star, τ_star)
+    @assert eltype(c_star) == eltype(v_star) == eltype(x_star)
+    return MIRKInterpTableau{
+        typeof(s_star),
+        typeof(c_star),
+        typeof(v_star),
+        typeof(x_star),
+        typeof(τ_star),
+    }(s_star,
+        c_star,
+        v_star,
+        x_star,
+        τ_star)
+end
+
+@truncate_stacktrace MIRKInterpTableau 1
 
 # ODE BVP problem system
 mutable struct BVPSystem{T, U <: AbstractArray, P, F, B, S}

--- a/src/mirk_tableaus.jl
+++ b/src/mirk_tableaus.jl
@@ -1,55 +1,77 @@
-function constructMIRK_IV(S::BVPSystem{T, U}) where {T, U}
+constructMIRK(S::BVPSystem) = MIRK_dispatcher(S, Val{S.order})
+MIRK_dispatcher(S::BVPSystem, ::Type{Val{4}}) = constructMIRK4(S)
+MIRK_dispatcher(S::BVPSystem, ::Type{Val{5}}) = constructMIRK5(S)
+MIRK_dispatcher(S::BVPSystem, ::Type{Val{6}}) = constructMIRK6(S)
+
+function constructMIRK4(S::BVPSystem{T, U}) where {T, U}
+    # RK coefficients tableau
+    s = 3
     c = [0, 1, 1 // 2, 3 // 4]
     v = [0, 1, 1 // 2, 27 // 32]
     b = [1 // 6, 1 // 6, 2 // 3, 0]
     x = [0 0 0 0
         0 0 0 0
-        1//8 -1//8 0 0
-        3//64 -9//64 0 0]
-    s = 3
+        1//8 -1//8 0 0]
+
+    # Interpolant tableau
     s_star = 4
-    tau = 0.226
-    MIRKTableau(T.(c), T.(v), T.(b), T.(x), Int64(s), Int64(s_star), T(tau))
+    c_star = [3 // 4]
+    v_star = [27 // 32]
+    x_star = [3 // 64, -9 // 64, 0, 0]
+    τ_star = 0.226
+
+    TU = MIRKTableau(Int64(s), T.(c), T.(v), T.(b), T.(x))
+    ITU = MIRKInterpTableau(Int64(s_star), T.(c_star), T.(v_star), T.(x_star), T(τ_star))
+    return TU, ITU
 end
 
-MIRK_dispatcher(S::BVPSystem, ::Type{Val{4}}) = constructMIRK_IV(S)
-
-function constructMIRK_V(S::BVPSystem{T, U}) where {T, U}
-    c = [0, 1, 3 // 4, 3 // 10, 4 // 5, 13 // 23]
-    v = [0, 1, 27 // 32, 837 // 1250, 4 // 5, 13 // 23]
-    b = [5 // 54, 1 // 14, 32 // 81, 250 // 567]
-    x = [0 0 0 0 0 0
-        0 0 0 0 0 0
-        3//64 -9//64 0 0 0 0
-        21//1000 63//5000 -252//625 0 0 0
-        14//1125 -74//875 -128//3375 104//945 0 0
-        1//2 4508233//1958887 48720832//2518569 -27646420//17629983 -11517095//559682 0]
+function constructMIRK5(S::BVPSystem{T, U}) where {T, U}
+    # RK coefficients tableau
     s = 4
+    c = [0, 1, 3 // 4, 3 // 10]
+    v = [0, 1, 27 // 32, 837 // 1250]
+    b = [5 // 54, 1 // 14, 32 // 81, 250 // 567]
+    x = [0 0 0 0
+        0 0 0 0
+        3//64 -9//64 0 0
+        21//1000 63//5000 -252//625 0]
+
+    # Interpolant tableau
     s_star = 6
-    tau = 0.3
-    MIRKTableau(T.(c), T.(v), T.(b), T.(x), Int64(s), Int64(s_star), T(tau))
+    c_star = [4 // 5, 13 // 23]
+    v_star = [4 // 5, 13 // 23]
+    x_star = [14//1125 -74//875 -128//3375 104//945 0 0
+        1//2 4508233//1958887 48720832//2518569 -27646420//17629983 -11517095//559682 0]
+    τ_star = 0.3
+
+    TU = MIRKTableau(Int64(s), T.(c), T.(v), T.(b), T.(x))
+    ITU = MIRKInterpTableau(Int64(s_star), T.(c_star), T.(v_star), T.(x_star), T(τ_star))
+    return TU, ITU
 end
 
-MIRK_dispatcher(S::BVPSystem, ::Type{Val{5}}) = constructMIRK_V(S)
-
-function constructMIRK_VI(S::BVPSystem{T, U}) where {T, U}
-    c = [0, 1, 1 // 4, 3 // 4, 1 // 2, 7 // 16, 1 // 8, 9 // 16, 3 // 8]
-    v = [0, 1, 5 // 32, 27 // 32, 1 // 2, 7 // 16, 1 // 8, 9 // 16, 3 // 8]
+function constructMIRK6(S::BVPSystem{T, U}) where {T, U}
+    # RK coefficients tableau
+    s = 5
+    c = [0, 1, 1 // 4, 3 // 4, 1 // 2]
+    v = [0, 1, 5 // 32, 27 // 32, 1 // 2]
     b = [7 // 90, 7 // 90, 16 // 45, 16 // 45, 2 // 15, 0, 0, 0, 0]
-    x = [0 0 0 0 0 0 0 0 0
-        0 0 0 0 0 0 0 0 0
-        9//64 -3//64 0 0 0 0 0 0 0
-        3//64 -9//64 0 0 0 0 0 0 0
-        -5//24 5//24 2//3 -2//3 0 0 0 0 0
-        1547//32768 -1225//32768 749//4096 -287//2048 -861//16384 0 0 0 0
+    x = [0 0 0 0 0
+        0 0 0 0 0
+        9//64 -3//64 0 0 0
+        3//64 -9//64 0 0 0
+        -5//24 5//24 2//3 -2//3 0]
+
+    # Interpolant tableau
+    s_star = 9
+    c_star = [7 // 16, 1 // 8, 9 // 16, 3 // 8]
+    v_star = [7 // 16, 1 // 8, 9 // 16, 3 // 8]
+    x_star = [1547//32768 -1225//32768 749//4096 -287//2048 -861//16384 0 0 0 0
         83//1536 -13//384 283//1536 -167//1536 -49//512 0 0 0 0
         1225//32768 -1547//32768 287//2048 -749//4096 861//16384 0 0 0 0
         233//3456 -19//1152 0 0 0 -5//72 7//72 -17//216 0]
-    s = 5
-    s_star = 9
-    tau = 0.7156
-    MIRKTableau(T.(c), T.(v), T.(b), T.(x), Int64(s), Int64(s_star), T(tau))
-end
+    τ_star = 0.7156
 
-constructMIRK(S::BVPSystem) = MIRK_dispatcher(S, Val{S.order})
-MIRK_dispatcher(S::BVPSystem, ::Type{Val{6}}) = constructMIRK_VI(S)
+    TU = MIRKTableau(Int64(s), T.(c), T.(v), T.(b), T.(x))
+    ITU = MIRKInterpTableau(Int64(s_star), T.(c_star), T.(v_star), T.(x_star), T(τ_star))
+    return TU, ITU
+end

--- a/test/mirk_convergence_tests.jl
+++ b/test/mirk_convergence_tests.jl
@@ -46,6 +46,9 @@ probArr = [
 
 testTol = 0.2
 affineTol = 1e-2
+dts1 = 1 .// 2 .^ (3:-1:1)
+dts2 = 1 .// 2 .^ (4:-1:3)
+dts3 = 1 .// 2 .^ (9:-1:6)
 
 println("Collocation method (GeneralMIRK)")
 println("Affineness Test")
@@ -70,18 +73,18 @@ println("Convergence Test on Linear")
 prob = probArr[2]
 
 # GeneralMIRK4
-dts = 1 .// 2 .^ (3:-1:1)
-@time sim = test_convergence(dts, prob, GeneralMIRK4(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts1, prob, GeneralMIRK4(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈4 atol=testTol
 
 # GeneralMIRK5
-dts = 1 .// 2 .^ (4:-1:3)
-@time sim = test_convergence(dts, prob, GeneralMIRK5(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts2, prob, GeneralMIRK5(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈5 atol=0.3
 
 # GeneralMIRK6
-dts = 1 .// 2 .^ (9:-1:6)
-@time sim = test_convergence(dts, prob, GeneralMIRK6(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts3, prob, GeneralMIRK6(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈6 atol=testTol
 
 println("Collocation method (MIRK)")
@@ -107,18 +110,18 @@ println("Convergence Test on Linear")
 prob = probArr[4]
 
 # MIRK4
-dts = 1 .// 2 .^ (3:-1:1)
-@time sim = test_convergence(dts, prob, MIRK4(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts1, prob, MIRK4(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈4 atol=testTol
 
 # MIRK5
-dts = 1 .// 2 .^ (4:-1:3)
-@time sim = test_convergence(dts, prob, MIRK5(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts2, prob, MIRK5(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈5 atol=0.3
 
 # MIRK6
-dts = 1 .// 2 .^ (9:-1:6)
-@time sim = test_convergence(dts, prob, MIRK6(); abstol = 1e-4, reltol = 1e-4);
+
+@time sim = test_convergence(dts3, prob, MIRK6(); abstol = 1e-4, reltol = 1e-4);
 @test sim.𝒪est[:final]≈6 atol=testTol
 
 using StaticArrays


### PR DESCRIPTION
The previous indexing in defect estimation is pretty weird, this PR adds ```MIRKInterpTableau``` to store the interpolants coefficients