### PR TITLE
Add MIRK3 method

### DIFF
--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -86,7 +86,7 @@ include("solve.jl")
 include("adaptivity.jl")
 
 export Shooting
-export GeneralMIRK4, GeneralMIRK5, GeneralMIRK6
-export MIRK4, MIRK5, MIRK6
+export GeneralMIRK3, GeneralMIRK4, GeneralMIRK5, GeneralMIRK6
+export MIRK3, MIRK4, MIRK5, MIRK6
 
 end

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -1,13 +1,17 @@
+alg_order(alg::GeneralMIRK3) = 3
 alg_order(alg::GeneralMIRK4) = 4
 alg_order(alg::GeneralMIRK5) = 5
 alg_order(alg::GeneralMIRK6) = 6
+alg_order(alg::MIRK3) = 3
 alg_order(alg::MIRK4) = 4
 alg_order(alg::MIRK5) = 5
 alg_order(alg::MIRK6) = 6
 
+alg_stage(alg::GeneralMIRK3) = 2
 alg_stage(alg::GeneralMIRK4) = 3
 alg_stage(alg::GeneralMIRK5) = 4
 alg_stage(alg::GeneralMIRK6) = 5
+alg_stage(alg::MIRK3) = 2
 alg_stage(alg::MIRK4) = 3
 alg_stage(alg::MIRK5) = 4
 alg_stage(alg::MIRK6) = 5

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -23,6 +23,20 @@ Shooting(ode_alg; nlsolve = DEFAULT_NLSOLVE_SHOOTING) = Shooting(ode_alg, nlsolv
   pages={479-497}
 }
 """
+struct GeneralMIRK3{N} <: GeneralMIRK
+    nlsolve::N
+end
+
+"""
+@article{Enright1996RungeKuttaSW,
+  title={Runge-Kutta Software with Defect Control for Boundary Value ODEs},
+  author={Wayne H. Enright and Paul H. Muir},
+  journal={SIAM J. Sci. Comput.},
+  year={1996},
+  volume={17},
+  pages={479-497}
+}
+"""
 struct GeneralMIRK4{N} <: GeneralMIRK
     nlsolve::N
 end
@@ -52,6 +66,20 @@ end
 }
 """
 struct GeneralMIRK6{N} <: GeneralMIRK
+    nlsolve::N
+end
+
+"""
+@article{Enright1996RungeKuttaSW,
+  title={Runge-Kutta Software with Defect Control for Boundary Value ODEs},
+  author={Wayne H. Enright and Paul H. Muir},
+  journal={SIAM J. Sci. Comput.},
+  year={1996},
+  volume={17},
+  pages={479-497}
+}
+"""
+struct MIRK3{N} <: MIRK
     nlsolve::N
 end
 
@@ -97,9 +125,11 @@ struct MIRK6{N} <: MIRK
     nlsolve::N
 end
 
+GeneralMIRK3(; nlsolve = DEFAULT_NLSOLVE_MIRK) = GeneralMIRK3(nlsolve)
 GeneralMIRK4(; nlsolve = DEFAULT_NLSOLVE_MIRK) = GeneralMIRK4(nlsolve)
 GeneralMIRK5(; nlsolve = DEFAULT_NLSOLVE_MIRK) = GeneralMIRK5(nlsolve)
 GeneralMIRK6(; nlsolve = DEFAULT_NLSOLVE_MIRK) = GeneralMIRK6(nlsolve)
+MIRK3(; nlsolve = DEFAULT_NLSOLVE_MIRK) = MIRK3(nlsolve)
 MIRK4(; nlsolve = DEFAULT_NLSOLVE_MIRK) = MIRK4(nlsolve)
 MIRK5(; nlsolve = DEFAULT_NLSOLVE_MIRK) = MIRK5(nlsolve)
 MIRK6(; nlsolve = DEFAULT_NLSOLVE_MIRK) = MIRK6(nlsolve)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -17,6 +17,18 @@ function alg_cache{T,U}(alg::MIRK4, S::BVPSystem{T,U})
 end
 =#
 
+mutable struct MIRK3GeneralCache{kType} <: GeneralMIRKCache
+    #k_discrete stores discrete stages for each subinterval,
+    #hence the size of k_discrete is n * (len*s)
+    k_discrete::kType
+end
+
+@truncate_stacktrace MIRK3GeneralCache
+
+function alg_cache(alg::Union{GeneralMIRK3, MIRK3}, S::BVPSystem{T, U}) where {T, U}
+    MIRK4GeneralCache(similar([S.y[1]], S.N - 1, S.s))
+end
+
 mutable struct MIRK4GeneralCache{kType} <: GeneralMIRKCache
     #k_discrete stores discrete stages for each subinterval,
     #hence the size of k_discrete is n * (len*s)

--- a/src/mirk_tableaus.jl
+++ b/src/mirk_tableaus.jl
@@ -1,7 +1,29 @@
 constructMIRK(S::BVPSystem) = MIRK_dispatcher(S, Val{S.order})
+MIRK_dispatcher(S::BVPSystem, ::Type{Val{3}}) = constructMIRK3(S)
 MIRK_dispatcher(S::BVPSystem, ::Type{Val{4}}) = constructMIRK4(S)
 MIRK_dispatcher(S::BVPSystem, ::Type{Val{5}}) = constructMIRK5(S)
 MIRK_dispatcher(S::BVPSystem, ::Type{Val{6}}) = constructMIRK6(S)
+
+function constructMIRK3(S::BVPSystem{T, U}) where {T, U}
+    # RK coefficients tableau
+    s = 2
+    c = [0, 2 // 3]
+    v = [0, 4 // 9]
+    b = [1 // 4, 3 // 4]
+    x = [0 1
+        2//9 0]
+
+    # Interpolant tableau
+    s_star = 3
+    c_star = [1]
+    v_star = [1]
+    x_star = [0, 0, 0]
+    τ_star = 0.25
+
+    TU = MIRKTableau(Int64(s), T.(c), T.(v), T.(b), T.(x))
+    ITU = MIRKInterpTableau(Int64(s_star), T.(c_star), T.(v_star), T.(x_star), T(τ_star))
+    return TU, ITU
+end
 
 function constructMIRK4(S::BVPSystem{T, U}) where {T, U}
     # RK coefficients tableau

--- a/src/mirk_tableaus.jl
+++ b/src/mirk_tableaus.jl
@@ -10,7 +10,7 @@ function constructMIRK3(S::BVPSystem{T, U}) where {T, U}
     c = [0, 2 // 3]
     v = [0, 4 // 9]
     b = [1 // 4, 3 // 4]
-    x = [0 1
+    x = [0 0
         2//9 0]
 
     # Interpolant tableau

--- a/test/mirk_convergence_tests.jl
+++ b/test/mirk_convergence_tests.jl
@@ -162,7 +162,7 @@ end
 
 u0 = MVector{2}([pi / 2, pi / 2])
 bvp1 = BVProblem(simplependulum!, bc1!, u0, tspan)
-@test_nowarn solve(bvp1, GeneralMIRK3(), dt = 0.05)
+@test_nowarn solve(bvp1, GeneralMIRK3(), dt = 0.005)
 @test_nowarn solve(bvp1, GeneralMIRK4(), dt = 0.05)
 @test_nowarn solve(bvp1, GeneralMIRK5(), dt = 0.05)
 @test_nowarn solve(bvp1, GeneralMIRK6(), dt = 0.05)

--- a/test/mirk_convergence_tests.jl
+++ b/test/mirk_convergence_tests.jl
@@ -54,6 +54,11 @@ println("Collocation method (GeneralMIRK)")
 println("Affineness Test")
 prob = probArr[1]
 
+# GeneralMIRK3
+
+@time sol = solve(prob, GeneralMIRK3(), dt = 0.2)
+@test norm(diff(first.(sol.u)) .+ 0.2, Inf) + abs(sol[1][1] - 5) < affineTol
+
 # GeneralMIRK4
 
 @time sol = solve(prob, GeneralMIRK4(), dt = 0.2)
@@ -71,6 +76,11 @@ prob = probArr[1]
 
 println("Convergence Test on Linear")
 prob = probArr[2]
+
+# GeneralMIRK3
+
+@time sim = test_convergence(dts2, prob, GeneralMIRK3(); abstol = 1e-3, reltol = 1e-3);
+@test sim.𝒪est[:final]≈3 atol=testTol
 
 # GeneralMIRK4
 
@@ -91,6 +101,11 @@ println("Collocation method (MIRK)")
 println("Affineness Test")
 prob = probArr[3]
 
+# MIRK3
+
+@time sol = solve(prob, MIRK3(), dt = 0.2)
+@test norm(diff(map(x -> x[1], sol.u)) .+ 0.2, Inf) .+ abs(sol[1][1] - 5) < affineTol
+
 # MIRK4
 
 @time sol = solve(prob, MIRK4(), dt = 0.2)
@@ -108,6 +123,11 @@ prob = probArr[3]
 
 println("Convergence Test on Linear")
 prob = probArr[4]
+
+# MIRK3
+
+@time sim = test_convergence(dts2, prob, MIRK3(); abstol = 1e-3, reltol = 1e-3);
+@test sim.𝒪est[:final]≈3 atol=testTol
 
 # MIRK4
 
@@ -142,6 +162,7 @@ end
 
 u0 = MVector{2}([pi / 2, pi / 2])
 bvp1 = BVProblem(simplependulum!, bc1!, u0, tspan)
+@test_nowarn solve(bvp1, GeneralMIRK3(), dt = 0.05)
 @test_nowarn solve(bvp1, GeneralMIRK4(), dt = 0.05)
 @test_nowarn solve(bvp1, GeneralMIRK5(), dt = 0.05)
 @test_nowarn solve(bvp1, GeneralMIRK6(), dt = 0.05)


### PR DESCRIPTION
This PR adds the MIRK3 method from [MIRKDC](https://netlib.org/ode/mirkdc.f)
![MIRK3](https://github.com/SciML/BoundaryValueDiffEq.jl/assets/52615090/518888f4-199b-40ca-b19e-b78e6add9d61)
