### PR TITLE
Add COLNEW algorithm

### DIFF
--- a/ext/BoundaryValueDiffEqODEInterfaceExt.jl
+++ b/ext/BoundaryValueDiffEqODEInterfaceExt.jl
@@ -4,14 +4,17 @@ using SciMLBase, BoundaryValueDiffEq, ODEInterface
 import SciMLBase: __solve
 import ODEInterface: OptionsODE, OPT_ATOL, OPT_RTOL, OPT_METHODCHOICE, OPT_DIAGNOSTICOUTPUT,
     OPT_ERRORCONTROL, OPT_SINGULARTERM, OPT_MAXSTEPS, OPT_BVPCLASS, OPT_SOLMETHOD,
-    OPT_RHS_CALLMODE, RHS_CALL_INSITU, evalSolution
+    OPT_RHS_CALLMODE, OPT_COLLOCATIONPTS, OPT_MAXSUBINTERVALS, RHS_CALL_INSITU, evalSolution
 import ODEInterface: Bvpm2, bvpm2_init, bvpm2_solve, bvpm2_destroy, bvpm2_get_x
 import ODEInterface: bvpsol
+import ODEInterface: colnew
 
-function _test_bvpm2_bvpsol_problem_criteria(_, ::SciMLBase.StandardBVProblem, alg::Symbol)
+import ForwardDiff
+
+function _test_bvpm2_bvpsol_colnew_problem_criteria(_, ::SciMLBase.StandardBVProblem, alg::Symbol)
     throw(ArgumentError("$(alg) does not support standard BVProblem. Only TwoPointBVProblem is supported."))
 end
-function _test_bvpm2_bvpsol_problem_criteria(prob, ::TwoPointBVProblem, alg::Symbol)
+function _test_bvpm2_bvpsol_colnew_problem_criteria(prob, ::TwoPointBVProblem, alg::Symbol)
     @assert isinplace(prob) "$(alg) only supports inplace TwoPointBVProblem!"
 end
 
@@ -19,8 +22,8 @@ end
 # BVPM2
 #------
 ## TODO: We can specify Drhs using forwarddiff if we want to
-function __solve(prob::BVProblem, alg::BVPM2; dt = 0.0, reltol = 1e-3, kwargs...)
-    _test_bvpm2_bvpsol_problem_criteria(prob, prob.problem_type, :BVPM2)
+function SciMLBase.__solve(prob::BVProblem, alg::BVPM2; dt = 0.0, reltol = 1e-3, kwargs...)
+    _test_bvpm2_bvpsol_colnew_problem_criteria(prob, prob.problem_type, :BVPM2)
 
     has_initial_guess = prob.u0 isa AbstractVector{<:AbstractArray}
     no_odes, n, u0 = if has_initial_guess
@@ -54,9 +57,8 @@ function __solve(prob::BVProblem, alg::BVPM2; dt = 0.0, reltol = 1e-3, kwargs...
 
     x_mesh = bvpm2_get_x(sol)
     evalsol = evalSolution(sol, x_mesh)
-    destats = SciMLBase.DEStats(stats["no_rhs_calls"], 0, 0, 0, stats["no_jac_calls"], 0, 0, 0, 0, 0, 0)
     sol_final = DiffEqBase.build_solution(prob, alg, x_mesh,
-        collect(Vector{eltype(evalsol)}, eachcol(evalsol)); retcode, stats = destats)
+        collect(Vector{eltype(evalsol)}, eachcol(evalsol)); retcode, stats)
 
     bvpm2_destroy(initial_guess)
     bvpm2_destroy(sol)
@@ -67,9 +69,9 @@ end
 #-------
 # BVPSOL
 #-------
-function __solve(prob::BVProblem, alg::BVPSOL; maxiters = 1000, reltol = 1e-3,
+function SciMLBase.__solve(prob::BVProblem, alg::BVPSOL; maxiters = 1000, reltol = 1e-3,
         dt = 0.0, verbose = true, kwargs...)
-    _test_bvpm2_bvpsol_problem_criteria(prob, prob.problem_type, :BVPSOL)
+        _test_bvpm2_bvpsol_colnew_problem_criteria(prob, prob.problem_type, :BVPSOL)
     @assert isa(prob.p, SciMLBase.NullParameters) "BVPSOL only supports NullParameters!"
     @assert isa(prob.u0, AbstractVector{<:AbstractArray}) "BVPSOL requires a vector of initial guesses!"
     n, u0 = (length(prob.u0) - 1), reduce(hcat, prob.u0)
@@ -117,6 +119,114 @@ function __solve(prob::BVProblem, alg::BVPSOL; maxiters = 1000, reltol = 1e-3,
     return DiffEqBase.build_solution(prob, alg, sol_t,
         collect(Vector{eltype(sol_x)}, eachcol(sol_x));
         retcode = retcode ≥ 0 ? ReturnCode.Success : ReturnCode.Failure, stats)
+end
+
+#-------
+# COLNEW
+#-------
+function SciMLBase.__solve(prob::BVProblem, alg::COLNEW; maxiters = 1000, reltol=1e-4, dt = 0.0, verbose = true, kwargs...)
+    _test_bvpm2_bvpsol_colnew_problem_criteria(prob, prob.problem_type, :COLNEW)
+    has_initial_guess = prob.u0 isa AbstractVector{<:AbstractArray}
+    dt ≤ 0 && throw(ArgumentError("dt must be positive"))
+    no_odes, n, u0 = if has_initial_guess
+        length(first(prob.u0)), (length(prob.u0) - 1), reduce(hcat, prob.u0)
+    else
+        length(prob.u0), Int(cld((prob.tspan[2] - prob.tspan[1]), dt)), prob.u0
+    end
+    T = eltype(u0)
+    mesh = collect(range(prob.tspan[1], stop = prob.tspan[2], length = n + 1))
+    opt = OptionsODE(OPT_BVPCLASS => alg.bvpclass, OPT_COLLOCATIONPTS => alg.collocationpts,
+        OPT_MAXSTEPS => maxiters, OPT_DIAGNOSTICOUTPUT => alg.diagnostic_output,
+        OPT_MAXSUBINTERVALS => alg.max_num_subintervals,  OPT_RTOL => reltol)
+    orders = ones(Int, no_odes)
+    _tspan = [prob.tspan[1], prob.tspan[2]]
+    iip = SciMLBase.isinplace(prob)
+
+    rhs(t, u, du) = if iip
+        prob.f(du, u, prob.p, t)
+    else
+        (du .= prob.f(u, prob.p, t))
+    end
+
+    if prob.f.jac === nothing
+        if iip
+            jac = function (df, u, p, t)
+                _du = similar(u)
+                prob.f(_du, u, p, t)
+                _f = (du, u) -> prob.f(du, u, p, t)
+                ForwardDiff.jacobian!(df, _f, _du, u)
+            end
+        else
+            jac = function (df, u, p, t)
+                _du = prob.f(u, p, t)
+                _f = (du, u) -> (du .= prob.f(u, p, t))
+                ForwardDiff.jacobian!(df, _f, _du, u)
+            end
+        end
+    else
+        jac = prob.f.jac
+    end
+    Drhs(t, u, df) = jac(df, u, prob.p, t)
+
+
+    #TODO: Fix bc and bcjac for multi-points BVP
+
+    n_bc_a = length(first(prob.f.bcresid_prototype.x))
+    n_bc_b = length(last(prob.f.bcresid_prototype.x))
+    zeta = vcat(fill(first(prob.tspan), n_bc_a), fill(last(prob.tspan), n_bc_b))
+    bc = function (i, z, resid)
+        tmpa = copy(z); tmpb = copy(z)
+        tmp_resid_a = zeros(T, n_bc_a)
+        tmp_resid_b = zeros(T, n_bc_b)
+        prob.f.bc[1](tmp_resid_a, tmpa, prob.p)
+        prob.f.bc[2](tmp_resid_b, tmpb, prob.p)
+
+        for j=1:n_bc_a
+            if i == j
+                resid[1] = tmp_resid_a[j]
+            end
+        end
+        for j=1:n_bc_b
+            if i == (j + n_bc_a)
+                resid[1] = tmp_resid_b[j]
+            end
+        end
+    end
+
+    Dbc = function (i, z, dbc)
+        for j=1:n_bc_a
+            if i == j
+                dbc[i] = 1.0
+            end
+        end
+        for j=1:n_bc_b
+            if i == (j + n_bc_a)
+                dbc[i] = 1.0
+            end
+        end
+    end
+
+    sol, retcode, stats = colnew(_tspan, orders, zeta, rhs, Drhs, bc, Dbc, nothing, opt)
+
+    if verbose
+        if retcode == 0
+            @warn "Collocation matrix is singular"
+        elseif retcode == -1
+            @warn "The expected no. of subintervals exceeds storage(try to increase `OPT_MAXSUBINTERVALS`)"
+        elseif retcode == -2
+            @warn "The nonlinear iteration has not converged"
+        elseif retcode == -3
+            @warn "There is an input data error"
+        end
+    end
+
+    evalsol = evalSolution(sol, mesh)
+    destats = SciMLBase.DEStats(stats["no_rhs_calls"], 0, 0, 0, stats["no_jac_calls"], 0, 0, 0, 0, 0, 0)
+
+    return DiffEqBase.build_solution(prob, alg, mesh,
+        collect(Vector{eltype(evalsol)}, eachrow(evalsol));
+        retcode = retcode > 0 ? ReturnCode.Success : ReturnCode.Failure,
+        stats = destats)
 end
 
 end

--- a/ext/BoundaryValueDiffEqODEInterfaceExt.jl
+++ b/ext/BoundaryValueDiffEqODEInterfaceExt.jl
@@ -54,11 +54,12 @@ function SciMLBase.__solve(prob::BVProblem, alg::BVPM2; dt = 0.0, reltol = 1e-3,
 
     sol, retcode, stats = bvpm2_solve(initial_guess, bvp2m_f, bvp2m_bc, opt)
     retcode = retcode ≥ 0 ? ReturnCode.Success : ReturnCode.Failure
+    destats = SciMLBase.DEStats(stats["no_rhs_calls"], 0, 0, 0, stats["no_jac_calls"], 0, 0, 0, 0, 0, 0)
 
     x_mesh = bvpm2_get_x(sol)
     evalsol = evalSolution(sol, x_mesh)
     sol_final = DiffEqBase.build_solution(prob, alg, x_mesh,
-        collect(Vector{eltype(evalsol)}, eachcol(evalsol)); retcode, stats)
+        collect(Vector{eltype(evalsol)}, eachcol(evalsol)); retcode, stats = destats)
 
     bvpm2_destroy(initial_guess)
     bvpm2_destroy(sol)

--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -160,6 +160,6 @@ export Shooting, MultipleShooting
 export MIRK2, MIRK3, MIRK4, MIRK5, MIRK6
 export MIRKJacobianComputationAlgorithm, BVPJacobianAlgorithm
 # From ODEInterface.jl
-export BVPM2, BVPSOL
+export BVPM2, BVPSOL, COLNEW
 
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -191,21 +191,28 @@ end
 Fortran code for solving two-point boundary value problems. For detailed documentation, see
 [ODEInterface.jl](https://github.com/luchr/ODEInterface.jl/blob/master/doc/SolverOptions.md#bvpm2).
 
+## Keyword Arguments:
+
+    - `max_num_subintervals`: Number of maximal subintervals, default as 3000.
+    - `method_choice`: Choice for IVP-solvers, default as Runge-Kutta method of order 4, available choices:
+        - `2`: Runge-Kutta method of order 2.
+        - `4`: Runge-Kutta method of order 4.
+        - `6`: Runge-Kutta method of order 6.
+    - `diagnostic_output`: Diagnostic output for BVPM2, default as non printout, available choices:
+        - `-1`: Full diagnostic printout.
+        - `0`: Selected printout.
+        - `1`: No printout.
+    - `error_control`: Determines the error-estimation for which RTOL is used, default as defect control, available choices:
+        - `1`: Defect control.
+        - `2`: Global error control.
+        - `3`: Defect and then global error control.
+        - `4`: Linear combination of defect and global error control.
+    - `singular_term`: either nothing if the ODEs have no singular terms at the left boundary or a constant (d,d) matrix for the
+        singular term.
+
 !!! warning
     Only supports inplace two-point boundary value problems, with very limited forms of
     input structures!
-
-## Arguments:
-
-    - `max_num_subintervals`: Maximum number of subintervals allowed, default as 3000.
-    - `method_choice`: The order of MIRK methods, choices are 2, 4 and 6, default as 4th order MIRK method.
-    - `diagnostic_output`: Diagnostic output level, choices are -1: no output, 0: only output if computation fails,
-        1: intermediate output, 2: full output, default as -1.
-    - `error_control`: Error control methods, choices are 1: defect control, 2: global error control,
-        3: defect then global error control, 4: linear combination of defect and global error control,
-        default as 1.
-    - `singular_term`: Either nothing if the ODEs have no singular terms at the left
-        boundary or a constant (d,d) matrix for the singular term, default as `nothing`
 
 !!! note
     Only available if the `ODEInterface` package is loaded.
@@ -228,6 +235,19 @@ of the arising linear subproblems, by Peter Deuflhard, Georg Bader, Lutz Weimann
 For detailed documentation, see
 [ODEInterface.jl](https://github.com/luchr/ODEInterface.jl/blob/master/doc/SolverOptions.md#bvpsol).
 
+## Keyword Arguments
+
+    - `bvpclass`: Boundary value problem classification, default as highly nonlinear with bad initial data, available choices:
+        - `0`: Linear boundary value problem.
+        - `1`: Nonlinear with good initial data.
+        - `2`: Highly Nonlinear with bad initial data.
+        - `3`: Highly nonlinear with bad initial data and initial rank reduction to seperable
+            linear boundary conditions.
+    - `sol_method`: Switch for solution methods, default as local linear solver with condensing algorithm, available choices:
+        - `0`: Use local linear solver with condensing algorithm.
+        - `1`: Use global sparse linear solver.
+    - `odesolver`: Either `nothing` or ode-solver(dopri5, dop853, seulex, etc.).
+
 !!! warning
     Only supports inplace two-point boundary value problems, with very limited forms of
     input structures!
@@ -239,4 +259,42 @@ Base.@kwdef struct BVPSOL{O} <: BoundaryValueDiffEqAlgorithm
     bvpclass::Int = 2
     sol_method::Int = 0
     odesolver::O = nothing
+end
+
+"""
+    COLNEW(; bvpclass = 2, collocationpts = 7, autodiff = :central)
+    COLNEW(bvpclass::Int, collocationpts::Int, autodiff)
+
+## Keyword Arguments:
+
+    - `bvpclass`: Boundary value problem classification, default as nonlinear and "extra sensitive", available choices:
+        - `0`: Linear boundary value problem.
+        - `1`: Nonlinear and regular.
+        - `2`: Nonlinear and "extra sensitive" (first relax factor is rstart and the
+            nonlinear iteration does not rely on past convergence).
+        - `3`: fail-early: return immediately upon:
+            (a) two successive non-convergences.
+            (b) after obtaining an error estimate for the first time.
+    - `collocationpts`: Number of collocation points per subinterval. Require orders[i] ≤ k ≤ 7, default as 7
+    - `diagnostic_output`: Diagnostic output for COLNEW, default as no printout, available choices:
+        - `-1`: Full diagnostic printout.
+        - `0`: Selected printout.
+        - `1`: No printout.
+    - `max_num_subintervals`: Number of maximal subintervals, default as 3000.
+
+A Fortran77 code solves a multi-points boundary value problems for a mixed order system of ODEs.
+It incorporates a new basis representation replacing b-splines, and improvements for
+the linear and nonlinear algebraic equation solvers.
+
+!!! warning
+    Only supports two-point boundary value problems.
+
+!!! note
+    Only available if the `ODEInterface` package is loaded.
+"""
+Base.@kwdef struct COLNEW <: BoundaryValueDiffEqAlgorithm
+    bvpclass::Int = 1
+    collocationpts::Int = 7
+    diagnostic_output::Int = 1
+    max_num_subintervals::Int = 3000
 end

--- a/test/misc/odeinterface_wrapper.jl
+++ b/test/misc/odeinterface_wrapper.jl
@@ -51,3 +51,23 @@ tpprob = TwoPointBVProblem(ex7_f2!, (ex7_2pbc1!, ex7_2pbc2!), initial_u0, tspan;
 # Just test that it runs. BVPSOL only works with linearly separable BCs.
 # TODO: Implement appolo reentry example from ODEInterface.jl
 sol_bvpsol = solve(tpprob, BVPSOL(); dt = π / 20)
+
+@info "COLNEW"
+
+function f!(du, u, p, t)
+    du[1] = u[2]
+    du[2] = u[1]
+end
+function bca!(resid_a, u_a, p)
+    resid_a[1] = u_a[1] - 1
+end
+function bcb!(resid_b, u_b, p)
+    resid_b[1] = u_b[1]
+end
+
+fun = BVPFunction(f!, (bca!, bcb!), bcresid_prototype = (zeros(1), zeros(1)), twopoint = Val(true))
+tspan = (0.0, 1.0)
+
+prob = TwoPointBVProblem(fun, [1.0, 0.0], tspan)
+sol_colnew = solve(prob, COLNEW(), dt = 0.01)
+@test SciMLBase.successful_retcode(sol_colnew)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,7 +55,7 @@ const GROUP = uppercase(get(ENV, "GROUP", "ALL"))
                 include("misc/type_stability.jl")
             end
             @time @safetestset "ODE Interface Tests" begin
-                include("misc/odeinterface_ex7.jl")
+                include("misc/odeinterface_wrapper.jl")
             end
             @time @safetestset "Initial Guess Function" begin
                 include("misc/initial_guess.jl")


### PR DESCRIPTION
Add COLNEW method from ODEInterface.jl.

1. The original COLNEW method supports multi-points BVP, its boundary condition must be defined as:
For example: if in time span $t = [-1, 1]$ we have boundary conditions $u(-1)=1, u'(0)=2.5, u(1)=5$, (here suppose `u[1]` is $u$, `u[2]` is $u'$)

```julia
zeta = [-1, 0, 1] # points in time span where we want to specify conditions
function bc(i, u, bc)
    if i == 1
        bc[1] = u[1] - 1.0
    elseif i == 2
        bc[1] = u[2] - 2.5
    elseif i == 3
        bc[1] = u[1] - 5.0
    end
end
......
sol, retcode, stats = colnew(tspan, orders, zeta, rhs, Drhs, bc, Dbc, nothing, opt)
```

the multi-points boundary condition definition in COLNEW makes it hard to convert to the API we are using here, so this PR only implemented the two-point case.

2. The initial guess is set to nothing because we support initial guess as initial guess value(set `u0` as `Vector`) during problem construction in BoundaryValueDiffEq.jl, whereas the initial guess in COLNEW can be [either `nothing` or the returned value from earlier COLNEW call](https://github.com/luchr/ODEInterface.jl/blob/master/doc/SolverOptions.md#guess)