### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -1,28 +1,26 @@
 module BoundaryValueDiffEq
 
-import PrecompileTools: @compile_workload, @setup_workload, @recompile_invalidations
+import PrecompileTools: @compile_workload, @setup_workload
 
-@recompile_invalidations begin
-    using ADTypes, Adapt, DiffEqBase, ForwardDiff, LinearAlgebra, NonlinearSolve,
-          OrdinaryDiffEq, Preferences, RecursiveArrayTools, Reexport, SciMLBase, Setfield,
-          SparseDiffTools
+using ADTypes, Adapt, DiffEqBase, ForwardDiff, LinearAlgebra, NonlinearSolve,
+      OrdinaryDiffEq, Preferences, RecursiveArrayTools, Reexport, SciMLBase, Setfield,
+      SparseDiffTools
 
-    using PreallocationTools: PreallocationTools, DiffCache
+using PreallocationTools: PreallocationTools, DiffCache
 
-    # Special Matrix Types
-    using BandedMatrices, FastAlmostBandedMatrices, SparseArrays
+# Special Matrix Types
+using BandedMatrices, FastAlmostBandedMatrices, SparseArrays
 
-    import ADTypes: AbstractADType
-    import ArrayInterface: matrix_colors, parameterless_type, undefmatrix,
-                           fast_scalar_indexing
-    import ConcreteStructs: @concrete
-    import DiffEqBase: solve
-    import FastClosures: @closure
-    import ForwardDiff: ForwardDiff, pickchunksize
-    import Logging
-    import RecursiveArrayTools: ArrayPartition, DiffEqArray
-    import SciMLBase: AbstractDiffEqInterpolation, StandardBVProblem, __solve, _unwrap_val
-end
+import ADTypes: AbstractADType
+import ArrayInterface: matrix_colors, parameterless_type, undefmatrix,
+                       fast_scalar_indexing
+import ConcreteStructs: @concrete
+import DiffEqBase: solve
+import FastClosures: @closure
+import ForwardDiff: ForwardDiff, pickchunksize
+import Logging
+import RecursiveArrayTools: ArrayPartition, DiffEqArray
+import SciMLBase: AbstractDiffEqInterpolation, StandardBVProblem, __solve, _unwrap_val
 
 @reexport using ADTypes, DiffEqBase, NonlinearSolve, OrdinaryDiffEq, SparseDiffTools,
                 SciMLBase


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.
