### PR TITLE
Use VectorOfArray for arrays in MIRK

### DIFF
--- a/src/adaptivity.jl
+++ b/src/adaptivity.jl
@@ -177,10 +177,10 @@ an interpolant
         yᵢ₂ .= (z′ .- yᵢ₂) ./ (abs.(yᵢ₂) .+ T(1))
         est₂ = maximum(abs, yᵢ₂)
 
-        defect[:, i] .= est₁ > est₂ ? yᵢ₁ : yᵢ₂
+        defect.u[i] .= est₁ > est₂ ? yᵢ₁ : yᵢ₂
     end
 
-    return maximum(Base.Fix1(maximum, abs), defect)
+    return maximum(Base.Fix1(maximum, abs), defect.u)
 end
 
 """

--- a/src/adaptivity.jl
+++ b/src/adaptivity.jl
@@ -177,7 +177,7 @@ an interpolant
         yᵢ₂ .= (z′ .- yᵢ₂) ./ (abs.(yᵢ₂) .+ T(1))
         est₂ = maximum(abs, yᵢ₂)
 
-        defect[i] .= est₁ > est₂ ? yᵢ₁ : yᵢ₂
+        defect[:, i] .= est₁ > est₂ ? yᵢ₁ : yᵢ₂
     end
 
     return maximum(Base.Fix1(maximum, abs), defect)
@@ -197,22 +197,22 @@ Here, the ki_interp is the stages in one subinterval.
         idx₁ = ((1:stage) .- 1) .* (s_star - stage) .+ r
         idx₂ = ((1:(r - 1)) .+ stage .- 1) .* (s_star - stage) .+ r
         for j in eachindex(k_discrete)
-            __maybe_matmul!(new_stages[j], k_discrete[j].du[:, 1:stage], x_star[idx₁])
+            __maybe_matmul!(new_stages.u[j], k_discrete[j].du[:, 1:stage], x_star[idx₁])
         end
         if r > 1
             for j in eachindex(k_interp)
                 __maybe_matmul!(
-                    new_stages[j], k_interp[j][:, 1:(r - 1)], x_star[idx₂], T(1), T(1))
+                    new_stages.u[j], k_interp.u[j][:, 1:(r - 1)], x_star[idx₂], T(1), T(1))
             end
         end
         for i in eachindex(new_stages)
-            new_stages[i] .= new_stages[i] .* mesh_dt[i] .+
+            new_stages.u[i] .= new_stages.u[i] .* mesh_dt[i] .+
                              (1 - v_star[r]) .* vec(y[i].du) .+
                              v_star[r] .* vec(y[i + 1].du)
             if iip
-                f(k_interp[i][:, r], new_stages[i], p, mesh[i] + c_star[r] * mesh_dt[i])
+                f(k_interp.u[i][:, r], new_stages.u[i], p, mesh[i] + c_star[r] * mesh_dt[i])
             else
-                k_interp[i][:, r] .= f(new_stages[i], p, mesh[i] + c_star[r] * mesh_dt[i])
+                k_interp.u[i][:, r] .= f(new_stages.u[i], p, mesh[i] + c_star[r] * mesh_dt[i])
             end
         end
     end
@@ -236,7 +236,7 @@ function sum_stages!(z::AbstractArray, cache::MIRKCache, w, i::Int, dt = cache.m
     z .= zero(z)
     __maybe_matmul!(z, k_discrete[i].du[:, 1:stage], w[1:stage])
     __maybe_matmul!(
-        z, k_interp[i][:, 1:(s_star - stage)], w[(stage + 1):s_star], true, true)
+        z, k_interp.u[i][:, 1:(s_star - stage)], w[(stage + 1):s_star], true, true)
     z .= z .* dt .+ cache.y₀[i]
 
     return z
@@ -249,12 +249,12 @@ end
     z .= zero(z)
     __maybe_matmul!(z, k_discrete[i].du[:, 1:stage], w[1:stage])
     __maybe_matmul!(
-        z, k_interp[i][:, 1:(s_star - stage)], w[(stage + 1):s_star], true, true)
+        z, k_interp.u[i][:, 1:(s_star - stage)], w[(stage + 1):s_star], true, true)
     z′ .= zero(z′)
     __maybe_matmul!(z′, k_discrete[i].du[:, 1:stage], w′[1:stage])
     __maybe_matmul!(
-        z′, k_interp[i][:, 1:(s_star - stage)], w′[(stage + 1):s_star], true, true)
-    z .= z .* dt[1] .+ cache.y₀[i]
+        z′, k_interp.u[i][:, 1:(s_star - stage)], w′[(stage + 1):s_star], true, true)
+    z .= z .* dt[1] .+ cache.y₀.u[i]
 
     return z, z′
 end

--- a/src/solve/mirk.jl
+++ b/src/solve/mirk.jl
@@ -149,13 +149,13 @@ function SciMLBase.solve!(cache::MIRKCache)
 
     u = recursivecopy(cache.y₀)
 
-    odesol = DiffEqBase.build_solution(cache.prob, cache.alg, cache.mesh, u;
-        interp = MIRKInterpolation(cache.mesh, u, cache), retcode = info)
+    odesol = DiffEqBase.build_solution(cache.prob, cache.alg, cache.mesh, u.u;
+        interp = MIRKInterpolation(cache.mesh, u.u, cache), retcode = info)
     return __build_solution(cache.prob, odesol, sol_nlprob)
 end
 
 function __perform_mirk_iteration(
-        cache::MIRKCache, abstol, adaptive::Bool; nlsolve_kwargs = (;), kwargs...)
+        cache::MIRKCache, abstol, adaptive::Bool; nlsolve_kwargs=(;), kwargs...)
     nlprob = __construct_nlproblem(cache, vec(cache.y₀))
     nlsolve_alg = __concrete_nonlinearsolve_algorithm(nlprob, cache.alg.nlsolve)
     sol_nlprob = __solve(


### PR DESCRIPTION
Part of #204 

Use `VectorOfArray` to replace `Vector{Vector}`.

The reason why using `VectorOfArray` instead of `DiffEqArray` is that some arrays, like `y₀` need extension when we halve the mesh and start a new nonlinear solving, and such extension for `DiffEqArray` is troublesome.