### PR TITLE
hotfix __unsafe_nonlinearfunction

### DIFF
--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/src/utils.jl
+++ b/lib/BoundaryValueDiffEqCore/src/utils.jl
@@ -254,9 +254,10 @@ struct __unsafe_nonlinearfunction{iip} end
         resid_prototype::RP = nothing) where {iip, F, J, JP, CV, RP}
     return NonlinearFunction{
         iip, SciMLBase.FullSpecialize, F, Nothing, Nothing, Nothing, J, Nothing,
-        Nothing, JP, Nothing, Nothing, Nothing, Nothing, Nothing, CV, Nothing, RP}(
+        Nothing, JP, Nothing, Nothing, Nothing, Nothing, Nothing, CV, Nothing, RP,
+        Nothing}(
         f, nothing, nothing, nothing, jac, nothing, nothing, jac_prototype, nothing,
-        nothing, nothing, nothing, nothing, colorvec, nothing, resid_prototype)
+        nothing, nothing, nothing, nothing, colorvec, nothing, resid_prototype, nothing)
 end
 
 # Construct the internal NonlinearProblem


### PR DESCRIPTION
However, this function is really bad. Can we please just remove it? It's not correct to `nothing` the other arguments: it's simply not a correct thing to do!!! This function should not exist and in its current form it will break every few months. It's a really bad idea.
