### PR TITLE
added support of complex numbers for mesh adaptivity in MIRK method

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/src/adaptivity.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/adaptivity.jl
@@ -31,8 +31,8 @@ Generate new mesh based on the defect.
     (abstol, _, _), kwargs = __split_mirk_kwargs(; cache.kwargs...)
     N = length(mesh)
 
-    safety_factor = T(1.3)
-    ρ = T(1.0) # Set rho=1 means mesh distribution will take place everytime.
+    safety_factor = abs.(T(1.3))
+    ρ = abs.(T(1.0)) # Set rho=1 means mesh distribution will take place everytime.
     Nsub_star = 0
     Nsub_star_ub = 4 * (N - 1)
     Nsub_star_lb = N ÷ 2
@@ -47,7 +47,7 @@ Generate new mesh based on the defect.
 
     n_predict = round(Int, (safety_factor * r₂) + 1)
     n = N - 1
-    n_ = T(0.1) * n
+    n_ = abs.(T(0.1)) * n
     n_predict = ifelse(abs((n_predict - n)) < n_, round(Int, n + n_), n_predict)
 
     if r₁ ≤ ρ * r₂


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added 
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Complex states seemed not to be compatible with mesh adaptivity. I just took the magnitude of the values in cache instead of their complex representation. Maybe not the best way, but it works...
