### PR TITLE
Fix 9 typos across multiple files

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# BoundaryValueDiffEq.jl: High-Performance Bounday Value Problem Solvers
+# BoundaryValueDiffEq.jl: High-Performance Boundary Value Problem Solvers
 
 BoundaryValueDiffEq.jl is a component package in the DifferentialEquations.jl ecosystem.
 The package includes its own high-performance BVP solvers which covers wide range of different kinds boundary value problems, includes the ability to swap out to fast direct and iterative nonlinear solvers, along with the ability to use sparse

--- a/lib/BoundaryValueDiffEqAscher/src/ascher_tableaus.jl
+++ b/lib/BoundaryValueDiffEqAscher/src/ascher_tableaus.jl
@@ -154,7 +154,7 @@ function vmonde!(rho, coef, k)
 end
 
 function rkbas!(s, coef, k::Integer, rkb, dm)
-    # for more guass collocation points per subinterval
+    # for more gauss collocation points per subinterval
     if k == 1
         rkb[1] = 1.0
         dm[1] = 1.0
@@ -178,7 +178,7 @@ function rkbas!(s, coef, k::Integer, rkb, dm)
 end
 
 function rkbas!(s, coef, k::Integer, rkb)
-    # for more guass collocation points per subinterval
+    # for more gauss collocation points per subinterval
     if k == 1
         rkb[1] = 1.0
         return

--- a/lib/BoundaryValueDiffEqCore/src/solution_utils.jl
+++ b/lib/BoundaryValueDiffEqCore/src/solution_utils.jl
@@ -1,4 +1,4 @@
-# Intermidiate solution evaluation
+# Intermediate solution evaluation
 @concrete struct EvalSol{C}
     u
     t

--- a/lib/BoundaryValueDiffEqFIRK/src/interpolation.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/interpolation.jl
@@ -306,7 +306,7 @@ end
 @inline __build_interpolation(cache::FIRKCacheNested,
     u::AbstractVector) = FIRKNestedInterpolation(cache.mesh, u, cache)
 
-# Intermidiate solution for evaluating boundry conditions
+# Intermediate solution for evaluating boundary conditions
 # basically simplified version of the interpolation for FIRK
 # Expanded FIRK
 function (s::EvalSol{C})(tval::Number) where {C <: FIRKCacheExpand}

--- a/lib/BoundaryValueDiffEqFIRK/test/expanded/firk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/expanded/firk_basic_tests.jl
@@ -44,7 +44,7 @@ function boundary!(residual, u, p, t)
 end
 boundary(u, p, t) = [u(0.0)[1] - 5, u(5.0)[1]]
 
-# Array indexing for boudnary conditions
+# Array indexing for boundary conditions
 function boundary_indexing!(residual, u, p, t)
     residual[1] = u[:, 1][1] - 5
     residual[2] = u[:, end][1]
@@ -340,7 +340,7 @@ end
             @test sol(0.001; idxs = 2)≈-1.312035941 atol=testTol
         end
 
-        @testset "Derivtive Interpolation tests for RadauIIa$stage" for stage in
+        @testset "Derivative Interpolation tests for RadauIIa$stage" for stage in
                                                                         (2, 3, 5, 7)
             @time sol = solve(prob_bvp_linear, radau_solver(Val(stage)); dt = 0.001)
             sol_analytic = prob_bvp_linear_analytic(nothing, λ, 0.04)

--- a/lib/BoundaryValueDiffEqFIRK/test/nested/firk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/nested/firk_basic_tests.jl
@@ -361,7 +361,7 @@ end
             @test sol(0.001; idxs = 2)≈-1.312035941 atol=testTol
         end
 
-        @testset "Derivtive Interpolation tests for RadauIIa$stage" for stage in
+        @testset "Derivative Interpolation tests for RadauIIa$stage" for stage in
                                                                         (2, 3, 5, 7)
             @time sol = solve(prob_bvp_linear, radau_solver(Val(stage)); dt = 0.001)
             sol_analytic = prob_bvp_linear_analytic(nothing, λ, 0.04)

--- a/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
@@ -142,7 +142,7 @@ end
 @inline __build_interpolation(
     cache::MIRKCache, u::AbstractVector) = MIRKInterpolation(cache.mesh, u, cache)
 
-# Intermidiate solution for evaluating boundry conditions
+# Intermediate solution for evaluating boundary conditions
 # basically simplified version of the interpolation for MIRK
 function (s::EvalSol{C})(tval::Number) where {C <: MIRKCache}
     (; t, u, cache) = s
@@ -162,7 +162,7 @@ function (s::EvalSol{C})(tval::Number) where {C <: MIRKCache}
     return z
 end
 
-# Interpolate intermidiate solution at multiple points
+# Interpolate intermediate solution at multiple points
 function (s::EvalSol{C})(tvals::AbstractArray{<:Number}) where {C <: MIRKCache}
     (; t, u, cache) = s
     (; alg, stage, k_discrete, mesh_dt) = cache
@@ -183,7 +183,7 @@ function (s::EvalSol{C})(tvals::AbstractArray{<:Number}) where {C <: MIRKCache}
     return zvals
 end
 
-# Intermidiate derivative solution for evaluating boundry conditions
+# Intermediate derivative solution for evaluating boundary conditions
 function (s::EvalSol{C})(tval::Number, ::Type{Val{1}}) where {C <: MIRKCache}
     (; t, u, cache) = s
     (; alg, stage, k_discrete, mesh_dt) = cache

--- a/lib/BoundaryValueDiffEqMIRK/test/mirk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/mirk_basic_tests.jl
@@ -27,7 +27,7 @@ function boundary!(residual, u, p, t)
 end
 boundary(u, p, t) = [u(0.0)[1] - 5, u(5.0)[1]]
 
-# Array indexing for boudnary conditions
+# Array indexing for boundary conditions
 function boundary_indexing!(residual, u, p, t)
     residual[1] = u[:, 1][1] - 5
     residual[2] = u[:, end][1]

--- a/lib/BoundaryValueDiffEqMIRKN/src/interpolation.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/interpolation.jl
@@ -1,4 +1,4 @@
-# Intermidiate solution for evaluating boundry conditions
+# Intermediate solution for evaluating boundary conditions
 # basically simplified version of the linear interpolation for MIRKN
 function (s::EvalSol{C})(tval::Number) where {C <: MIRKNCache}
     (; t, u, cache) = s

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -76,7 +76,7 @@ For detailed documentation, see
         - `1`: Nonlinear with good initial data.
         - `2`: Highly Nonlinear with bad initial data.
         - `3`: Highly nonlinear with bad initial data and initial rank reduction to
-          seperable linear boundary conditions.
+          separable linear boundary conditions.
     - `sol_method`: Switch for solution methods, default as local linear solver with
       condensing algorithm, available choices:
         - `0`: Use local linear solver with condensing algorithm.

--- a/test/misc/bigfloat_test.jl
+++ b/test/misc/bigfloat_test.jl
@@ -17,7 +17,7 @@
     u0 = BigFloat.([pi / 2, pi / 2])
     multi_point_bvp = BVProblem(simplependulum!, bc!, u0, tspan)
 
-    @testset "BigFloat compatiability with Multi-point BVP" begin
+    @testset "BigFloat compatibility with Multi-point BVP" begin
         for solver in [MIRK4(), RadauIIa5(), LobattoIIIa4(nested_nlsolve = true)]
             sol = solve(multi_point_bvp, solver, dt = 0.05)
             @test SciMLBase.successful_retcode(sol.retcode)
@@ -39,7 +39,7 @@
     tspan = (0.0, 1.0)
     two_point_bvp = BVProblem(bvp_function, BigFloat.([1.0, 0.0]), tspan)
 
-    @testset "BigFloat compatiability with Two-point BVP" begin
+    @testset "BigFloat compatibility with Two-point BVP" begin
         for solver in [MIRK4(), RadauIIa5(), LobattoIIIa4(nested_nlsolve = true)]
             sol = solve(two_point_bvp, solver, dt = 0.05)
             @test SciMLBase.successful_retcode(sol.retcode)


### PR DESCRIPTION
## Summary\n\nThis PR fixes legitimate typos found by the typos-cli tool.\n\n## Changes\n\nFixed 9 different typos with 20 total corrections:\n\n- `Bounday` → `Boundary` (1 occurrences)\n- `seperable` → `separable` (1 occurrences)\n- `boudnary` → `boundary` (2 occurrences)\n- `intermidiate` → `intermediate` (1 occurrences)\n- `Intermidiate` → `Intermediate` (5 occurrences)\n- `boundry` → `boundary` (4 occurrences)\n- `Derivtive` → `Derivative` (2 occurrences)\n- `guass` → `gauss` (2 occurrences)\n- `compatiability` → `compatibility` (2 occurrences)\n\n## Files Modified\n\n- docs/src/index.md\n- lib/BoundaryValueDiffEqAscher/src/ascher_tableaus.jl\n- lib/BoundaryValueDiffEqCore/src/solution_utils.jl\n- lib/BoundaryValueDiffEqFIRK/src/interpolation.jl\n- lib/BoundaryValueDiffEqFIRK/test/expanded/firk_basic_tests.jl\n- lib/BoundaryValueDiffEqFIRK/test/nested/firk_basic_tests.jl\n- lib/BoundaryValueDiffEqMIRK/src/interpolation.jl\n- lib/BoundaryValueDiffEqMIRK/test/mirk_basic_tests.jl\n- lib/BoundaryValueDiffEqMIRKN/src/interpolation.jl\n- src/extension_algs.jl\n- test/misc/bigfloat_test.jl\n\n🤖 Generated automatically by typos-cli analysis