### PR TITLE
Disable qa_tests.jl from default test runs

### DIFF
--- a/test/misc/qa_tests.jl
+++ b/test/misc/qa_tests.jl
@@ -1,10 +1,10 @@
-@testitem "Quality Assurance" begin
+@testitem "Quality Assurance" tags=[:qa] begin
     using Aqua
 
     Aqua.test_all(BoundaryValueDiffEq; ambiguities = false)
 end
 
-@testitem "JET Package Test" begin
+@testitem "JET Package Test" tags=[:qa] begin
     using JET
 
     JET.test_package(BoundaryValueDiffEq, target_defined_modules = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,5 +14,5 @@ const RETESTITEMS_NWORKER_THREADS = parse(Int,
 @info "Running tests for group: $(GROUP) with $(RETESTITEMS_NWORKERS) workers"
 
 ReTestItems.runtests(
-    BoundaryValueDiffEq; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
+    BoundaryValueDiffEq; tags = (GROUP == "all" ? [:!qa] : (GROUP == "qa" ? [:qa] : [Symbol(GROUP)])),
     nworkers = RETESTITEMS_NWORKERS, nworker_threads = RETESTITEMS_NWORKER_THREADS)


### PR DESCRIPTION
## Summary
- Excludes qa_tests.jl (Quality Assurance and JET tests) from the default "All" test group
- QA tests can still be run explicitly with GROUP=qa
- Tests are now tagged with `:qa` tag to enable selective execution

## Changes
- Added `:qa` tag to both test items in `test/misc/qa_tests.jl`
- Modified `test/runtests.jl` to exclude `:qa` tagged tests when GROUP=all
- QA tests can still be run explicitly by setting GROUP=qa

## Motivation
This change prevents QA tests from running in the default pre-test configuration while still allowing them to be run when specifically requested.

🤖 Generated with [Claude Code](https://claude.ai/code)