### PR TITLE
Dedent markdown in docstrings

### DIFF
--- a/lib/BoundaryValueDiffEqMIRKN/src/algorithms.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/algorithms.jl
@@ -6,31 +6,31 @@ for order in (4, 6)
 
     @eval begin
         """
-              $($alg)(; nlsolve = NewtonRaphson(), optimize = nothing, jac_alg = BVPJacobianAlgorithm(),
-                      defect_threshold = 0.1, max_num_subintervals = 3000)
+            $($alg)(; nlsolve = NewtonRaphson(), optimize = nothing, jac_alg = BVPJacobianAlgorithm(),
+                    defect_threshold = 0.1, max_num_subintervals = 3000)
 
         $($order)th order Monotonic Implicit Runge Kutta Nyström method.
 
         ## Keyword Arguments
 
-            - `nlsolve`: Internal Nonlinear solver. Any solver which conforms to the SciML
-              `NonlinearProblem` interface can be used. Note that any autodiff argument for
-              the solver will be ignored and a custom jacobian algorithm will be used.
-            - `optimize`: Internal Optimization solver. Any solver which conforms to the SciML
-              `OptimizationProblem` interface can be used. Note that any autodiff argument for
-              the solver will be ignored and a custom jacobian algorithm will be used. Optimization
-              solvers should first be loaded to allow this functionality.
-            - `jac_alg`: Jacobian Algorithm used for the nonlinear solver. Defaults to
-              `BVPJacobianAlgorithm()`, which automatically decides the best algorithm to
-              use based on the input types and problem type.
-              - For `TwoPointBVProblem`, only `diffmode` is used (defaults to
-                `AutoSparse(AutoForwardDiff())` if possible else `AutoSparse(AutoFiniteDiff())`).
-              - For `BVProblem`, `bc_diffmode` and `nonbc_diffmode` are used. For
-                `nonbc_diffmode` defaults to `AutoSparse(AutoForwardDiff())` if possible else
-                `AutoSparse(AutoFiniteDiff())`. For `bc_diffmode`, defaults to `AutoForwardDiff` if
-                possible else `AutoFiniteDiff`.
-            - `defect_threshold`: Threshold for defect control.
-            - `max_num_subintervals`: Number of maximal subintervals, default as 3000.
+        - `nlsolve`: Internal Nonlinear solver. Any solver which conforms to the SciML
+          `NonlinearProblem` interface can be used. Note that any autodiff argument for
+          the solver will be ignored and a custom jacobian algorithm will be used.
+        - `optimize`: Internal Optimization solver. Any solver which conforms to the SciML
+          `OptimizationProblem` interface can be used. Note that any autodiff argument for
+          the solver will be ignored and a custom jacobian algorithm will be used. Optimization
+          solvers should first be loaded to allow this functionality.
+        - `jac_alg`: Jacobian Algorithm used for the nonlinear solver. Defaults to
+          `BVPJacobianAlgorithm()`, which automatically decides the best algorithm to
+          use based on the input types and problem type.
+          - For `TwoPointBVProblem`, only `diffmode` is used (defaults to
+            `AutoSparse(AutoForwardDiff())` if possible else `AutoSparse(AutoFiniteDiff())`).
+          - For `BVProblem`, `bc_diffmode` and `nonbc_diffmode` are used. For
+            `nonbc_diffmode` defaults to `AutoSparse(AutoForwardDiff())` if possible else
+            `AutoSparse(AutoFiniteDiff())`. For `bc_diffmode`, defaults to `AutoForwardDiff` if
+            possible else `AutoFiniteDiff`.
+        - `defect_threshold`: Threshold for defect control.
+        - `max_num_subintervals`: Number of maximal subintervals, default as 3000.
 
         !!! note
 

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -10,26 +10,25 @@ Fortran code for solving two-point boundary value problems. For detailed documen
 
 ## Keyword Arguments:
 
-    - `max_num_subintervals`: Number of maximal subintervals, default as 3000.
-    - `method_choice`: Choice for IVP-solvers, default as Runge-Kutta method of order 4,
-      available choices:
-        - `2`: Runge-Kutta method of order 2.
-        - `4`: Runge-Kutta method of order 4.
-        - `6`: Runge-Kutta method of order 6.
-    - `diagnostic_output`: Diagnostic output for BVPM2, default as non printout, available
-      choices:
-        - `-1`: Full diagnostic printout.
-        - `0`: Selected printout.
-        - `1`: No printout.
-    - `error_control`: Determines the error-estimation for which RTOL is used, default as
-      defect control, available choices:
-        - `1`: Defect control.
-        - `2`: Global error control.
-        - `3`: Defect and then global error control.
-        - `4`: Linear combination of defect and global error control.
-    - `singular_term`: either nothing if the ODEs have no singular terms at the left
-      boundary or a constant (d,d) matrix for the
-        singular term.
+- `max_num_subintervals`: Number of maximal subintervals, default as 3000.
+- `method_choice`: Choice for IVP-solvers, default as Runge-Kutta method of order 4,
+  available choices:
+    - `2`: Runge-Kutta method of order 2.
+    - `4`: Runge-Kutta method of order 4.
+    - `6`: Runge-Kutta method of order 6.
+- `diagnostic_output`: Diagnostic output for BVPM2, default as non printout, available
+  choices:
+    - `-1`: Full diagnostic printout.
+    - `0`: Selected printout.
+    - `1`: No printout.
+- `error_control`: Determines the error-estimation for which RTOL is used, default as
+  defect control, available choices:
+    - `1`: Defect control.
+    - `2`: Global error control.
+    - `3`: Defect and then global error control.
+    - `4`: Linear combination of defect and global error control.
+- `singular_term`: either nothing if the ODEs have no singular terms at the left
+  boundary or a constant (d,d) matrix for the singular term.
 
 !!! note
 
@@ -70,18 +69,18 @@ For detailed documentation, see
 
 ## Keyword Arguments
 
-    - `bvpclass`: Boundary value problem classification, default as highly nonlinear with
-      bad initial data, available choices:
-        - `0`: Linear boundary value problem.
-        - `1`: Nonlinear with good initial data.
-        - `2`: Highly Nonlinear with bad initial data.
-        - `3`: Highly nonlinear with bad initial data and initial rank reduction to
-          separable linear boundary conditions.
-    - `sol_method`: Switch for solution methods, default as local linear solver with
-      condensing algorithm, available choices:
-        - `0`: Use local linear solver with condensing algorithm.
-        - `1`: Use global sparse linear solver.
-    - `odesolver`: Either `nothing` or ode-solver(dopri5, dop853, seulex, etc.).
+- `bvpclass`: Boundary value problem classification, default as highly nonlinear with
+  bad initial data, available choices:
+    - `0`: Linear boundary value problem.
+    - `1`: Nonlinear with good initial data.
+    - `2`: Highly Nonlinear with bad initial data.
+    - `3`: Highly nonlinear with bad initial data and initial rank reduction to
+      separable linear boundary conditions.
+- `sol_method`: Switch for solution methods, default as local linear solver with
+  condensing algorithm, available choices:
+    - `0`: Use local linear solver with condensing algorithm.
+    - `1`: Use global sparse linear solver.
+- `odesolver`: Either `nothing` or ode-solver(dopri5, dop853, seulex, etc.).
 
 !!! note
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Prevent them from being parsed as code blocks.
Changes the MIRKN docstrings and BVPSOL/BVPM2