### PR TITLE
Fix JET.jl static analysis issues

### DIFF
--- a/lib/BoundaryValueDiffEqAscher/src/algorithms.jl
+++ b/lib/BoundaryValueDiffEqAscher/src/algorithms.jl
@@ -49,10 +49,10 @@ for stage in (1, 2, 3, 4, 5, 6, 7)
         }
         ```
         """
-        @kwdef struct $(alg){N, O, J <: BVPJacobianAlgorithm} <: AbstractAscher
+        @kwdef struct $(alg){N, O, Z, J <: BVPJacobianAlgorithm} <: AbstractAscher
             nlsolve::N = nothing
             optimize::O = nothing
-            zeta::Vector{Float64} = nothing
+            zeta::Z = nothing
             jac_alg::J = BVPJacobianAlgorithm()
             max_num_subintervals::Int = 3000
         end

--- a/lib/BoundaryValueDiffEqCore/src/utils.jl
+++ b/lib/BoundaryValueDiffEqCore/src/utils.jl
@@ -292,6 +292,7 @@ function __extract_problem_details(prob, u0::SciMLBase.ODESolution; dt = 0.0,
     if fit_parameters
         prob.p isa SciMLBase.NullParameters &&
             throw(ArgumentError("`fit_parameters` is true but `prob.p` is not set."))
+        t₀, t₁ = prob.tspan
         new_u = vcat(_u0, prob.p)
         return Val(false), eltype(new_u), length(new_u), Int(cld(t₁ - t₀, dt)), new_u
     end

--- a/lib/BoundaryValueDiffEqFIRK/src/firk.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/firk.jl
@@ -828,7 +828,7 @@ end
 @views function __firk_loss!(resid, u, p, y, pt::TwoPointBVProblem, bc!::Tuple{BC1, BC2},
         residual, mesh, cache, _, trait::NoDiffCacheNeeded) where {BC1, BC2}
     y_ = recursive_unflatten!(y, u)
-    soly_ = VectorOfArray(y_)
+    soly_ = y_ isa AbstractVectorOfArray ? y_ : VectorOfArray(y_)
     resida = residual[1][1:prod(cache.resid_size[1])]
     residb = residual[1][(prod(cache.resid_size[1]) + 1):end]
     eval_bc_residual!((resida, residb), pt, bc!, soly_, p, mesh)

--- a/lib/BoundaryValueDiffEqShooting/src/multiple_shooting.jl
+++ b/lib/BoundaryValueDiffEqShooting/src/multiple_shooting.jl
@@ -29,6 +29,8 @@ function SciMLBase.__solve(
 
     nshoots = alg.nshoots
 
+    resida_len = 0
+    residb_len = 0
     if prob.problem_type isa TwoPointBVProblem
         resida_len = prod(resid_size[1])
         residb_len = prod(resid_size[2])


### PR DESCRIPTION
## Summary

This PR fixes several issues found by JET.jl static analysis across multiple sublibraries:

- **BoundaryValueDiffEqCore**: Fix undefined `t₀` and `t₁` variables in `__extract_problem_details` when handling ODESolution with `fit_parameters=true`
- **BoundaryValueDiffEqFIRK**: Fix potential method error when calling `VectorOfArray` on an `AbstractVectorOfArray` - now properly checks if input is already an AbstractVectorOfArray
- **BoundaryValueDiffEqAscher**: Fix type incompatibility in Ascher algorithm structs where `zeta::Vector{Float64}` had default value `nothing`. Changed to parameterized type `zeta::Z` to allow both `Nothing` and `Vector{Float64}`
- **BoundaryValueDiffEqShooting**: Initialize `resida_len` and `residb_len` before conditional blocks to satisfy JET's static analysis

## Test plan

- [x] Ran JET.jl analysis on all sublibraries - no errors detected after fixes
- [x] Ran basic solver tests (Shooting, MIRK2, Ascher constructors) - all pass
- [x] Ran `Pkg.test()` - core functionality tests pass (some pre-existing test failures unrelated to these changes)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)