### PR TITLE
Fix default `zeta` in struct definition 

### DIFF
--- a/lib/BoundaryValueDiffEqAscher/src/algorithms.jl
+++ b/lib/BoundaryValueDiffEqAscher/src/algorithms.jl
@@ -52,7 +52,7 @@ for stage in (1, 2, 3, 4, 5, 6, 7)
         @kwdef struct $(alg){N, O, J <: BVPJacobianAlgorithm} <: AbstractAscher
             nlsolve::N = nothing
             optimize::O = nothing
-            zeta::Vector{Float64} = nothing
+            zeta::Vector{Float64} = Float64[]
             jac_alg::J = BVPJacobianAlgorithm()
             max_num_subintervals::Int = 3000
         end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
