### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.21.0"
+version = "5.22.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -60,7 +60,7 @@ Random = "1.10"
 ReTestItems = "1.29"
 RecursiveArrayTools = "3.31.2"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 Sparspak = "0.3.11"
 StaticArrays = "1.9.8"
 Test = "1.10"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -36,7 +36,7 @@ Random = "1.10"
 ReTestItems = "1.23.1"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 Setfield = "1.1.1"
 StaticArrays = "1.9.8"
 Test = "1.10"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]
@@ -45,7 +45,7 @@ OptimizationBase = "5.1"
 PreallocationTools = "1.2"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 SciMLLogging = "1.8.0"
 SciMLStructures = "1.7.0"
 Setfield = "1"

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -53,7 +53,7 @@ Random = "1.10"
 ReTestItems = "1.23.1"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 SciMLStructures = "1.7.0"
 Setfield = "1.1.1"
 SparseArrays = "1.10"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -53,7 +53,7 @@ Random = "1.10"
 ReTestItems = "1.23.1"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 SciMLStructures = "1.7.0"
 Setfield = "1.1.1"
 SparseArrays = "1.10"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -48,7 +48,7 @@ Random = "1.10"
 ReTestItems = "1.23.1"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 Setfield = "1.1.1"
 SparseArrays = "1.10"
 StaticArrays = "1.9.8"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -51,7 +51,7 @@ Random = "1.10"
 ReTestItems = "1.23.1"
 RecursiveArrayTools = "3.27.0"
 Reexport = "1.2"
-SciMLBase = "2.152.1"
+SciMLBase = "2.152.1, 3"
 Setfield = "1.1.1"
 SparseArrays = "1.10"
 StaticArrays = "1.9.8"


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3 (in main Project.toml and all lib sub-packages)
- Bump package version 5.21.0 → 5.22.0 (minor); also bumped all lib sub-packages
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns

Supersedes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)