### PR TITLE
Bump BoundaryValueDiffEqCore lower bound to 2.2 in FIRK and MIRK

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
-version = "1.13.0"
+version = "1.13.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -32,7 +32,7 @@ ADTypes = "1.14"
 Aqua = "0.8"
 ArrayInterface = "7.18"
 BandedMatrices = "1.7.5"
-BoundaryValueDiffEqCore = "2.0"
+BoundaryValueDiffEqCore = "2.2"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44"
 DifferentiationInterface = "0.7"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
-version = "1.13.0"
+version = "1.13.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -31,7 +31,7 @@ ADTypes = "1.14"
 Aqua = "0.8"
 ArrayInterface = "7.18"
 BandedMatrices = "1.7.5"
-BoundaryValueDiffEqCore = "2.0"
+BoundaryValueDiffEqCore = "2.2"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44"
 DifferentiationInterface = "0.7"


### PR DESCRIPTION
## Summary
- Raises the `BoundaryValueDiffEqCore` compat lower bound from `2.0` to `2.2` in `BoundaryValueDiffEqFIRK` and `BoundaryValueDiffEqMIRK`, and bumps each subpackage patch version to `1.13.1`.

## Why
The `tune_parameters` keyword on `__initial_guess_on_mesh` was only merged to master in #465 (Apr 6, 2026), which shipped as `BoundaryValueDiffEqCore` 2.2.0. FIRK and MIRK call `__initial_guess_on_mesh(..., tune_parameters = ...)`, but both still declared `BoundaryValueDiffEqCore = "2.0"` compat. That lets the resolver pair the current FIRK/MIRK (which pass the kwarg) with Core 2.0.x / 2.1.x (which do not accept it).

This is the root cause of #468: when an unrelated package (Dash) pins `DataStructures` back to 0.18, Pkg cascades downgrades elsewhere in the environment and lands on a FIRK/MIRK + old-Core combination that throws `MethodError: no method matching __initial_guess_on_mesh(...; tune_parameters::Bool)` at precompile time.

Only FIRK and MIRK call `tune_parameters`; MIRKN / Ascher / Shooting don't, so they're left alone. With FIRK/MIRK pinning Core ≥ 2.2, the whole `BoundaryValueDiffEq` metapackage resolves consistently on Core 2.2 anyway.

Fixes #468.

## Test plan
- [ ] CI on this PR