### PR TITLE
Set top-level version to 5.21.0 for sequential registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.22.0"
+version = "5.21.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

The last registered top-level `BoundaryValueDiffEq` version is 5.20.0. `Project.toml` was bumped to 5.21.0 in a prior change but never registered on General, and PR #475 then bumped straight to 5.22.0. AutoMerge on [General#153623](https://github.com/JuliaRegistries/General/pull/153623) rejected 5.22.0 for skipping 5.21.0.

This reverts the top-level `version` in `Project.toml` to `5.21.0` so we can register the skipped version first. A follow-up can then bump to 5.22.0 and re-register.

No source or compat changes.

## Test plan
- [ ] After merge, register 5.21.0 via `@JuliaRegistrator register` on the merge commit — expect AutoMerge to accept (sequential from 5.20.0).