### PR TITLE
Fix precompile MethodError when DiffEqBase DEVerbosity flows through as default verbose

### DIFF
--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqCore/src/verbosity.jl
+++ b/lib/BoundaryValueDiffEqCore/src/verbosity.jl
@@ -355,3 +355,10 @@ end
 end
 
 @inline _process_verbose_param(verbose::BVPVerbosity) = verbose
+
+# A foreign AbstractVerbositySpecifier (e.g. DiffEqBase.DEVerbosity) can flow in
+# through DiffEqBase's `solve`/`init` default kwargs (`verbose = DEFAULT_VERBOSE`,
+# which is a `DEVerbosity`). BVPVerbosity's toggles differ from DEVerbosity's, so
+# we cannot meaningfully translate it; fall back to BVP's own default rather than
+# dispatch-missing at precompile time.
+@inline _process_verbose_param(::SciMLLogging.AbstractVerbositySpecifier) = DEFAULT_VERBOSE

--- a/lib/BoundaryValueDiffEqCore/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqCore/test/runtests.jl
@@ -11,4 +11,15 @@ using InteractiveUtils, Test
         Aqua.test_piracies(BoundaryValueDiffEqCore)
         Aqua.test_ambiguities(BoundaryValueDiffEqCore; recursive = false)
     end
+
+    @testset "_process_verbose_param foreign AbstractVerbositySpecifier" begin
+        # DiffEqBase.DEVerbosity is a foreign AbstractVerbositySpecifier that
+        # can flow in via DiffEqBase's `solve`/`init` default `verbose` kwarg.
+        # It must not hit a MethodError at precompile time; it should fall
+        # back to BVP's own DEFAULT_VERBOSE (a BVPVerbosity).
+        using BoundaryValueDiffEqCore, DiffEqBase
+        result = BoundaryValueDiffEqCore._process_verbose_param(DiffEqBase.DEFAULT_VERBOSE)
+        @test result isa BoundaryValueDiffEqCore.BVPVerbosity
+        @test result === BoundaryValueDiffEqCore.DEFAULT_VERBOSE
+    end
 end


### PR DESCRIPTION
## Summary

Fixes precompile failure of `BoundaryValueDiffEqFIRK` (and other BVP sublibraries) caused by a cross-module dispatch gap in `_process_verbose_param`.

## Root cause

`DiffEqBase` recently switched `init`/`solve` to default `verbose = DiffEqBase.DEFAULT_VERBOSE` (a `DEVerbosity`), where it previously used `verbose = true` (a `Bool`). That value is passed through `kwargs...` into `BoundaryValueDiffEqFIRK.__init` / `init_expanded` / `init_nested`, which call `_process_verbose_param` on it.

`BoundaryValueDiffEqCore`'s `_process_verbose_param` (the binding that resolves inside every BVP sublibrary) has methods for `::SciMLLogging.AbstractVerbosityPreset`, `::Bool`, and `::BVPVerbosity`. It has no method for `DEVerbosity` (or for any other foreign `AbstractVerbositySpecifier`), so it throws:

```
MethodError: no method matching _process_verbose_param(::DiffEqBase.DEVerbosity{...})
```

…at precompile time, during the `@compile_workload` `solve(prob, alg; dt = 0.2)` call in `BoundaryValueDiffEqFIRK`.

This was surfaced in OrdinaryDiffEq.jl [Sublibrary CI run 24859020070](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070) on jobs `test (DiffEqDevTools, 1, ubuntu-latest, 120, 1)` and `test (DiffEqDevTools_QA, 1, ubuntu-latest, 120, 1)` (which test against `BoundaryValueDiffEq`).

## Fix

Add a fallback method

```julia
_process_verbose_param(::SciMLLogging.AbstractVerbositySpecifier) = DEFAULT_VERBOSE
```

to `BoundaryValueDiffEqCore`. `BVPVerbosity` and `DEVerbosity` have disjoint toggle sets, so we can't meaningfully translate one to the other; falling back to BVP's own `DEFAULT_VERBOSE` keeps downstream `@SciMLMessage(..., verb, :bvp_specific_toggle)` calls correct. The existing `::BVPVerbosity` method is more specific, so user-constructed BVPVerbosity values still dispatch unchanged.

## Verification

Locally reproduced the `MethodError` on `Pkg.precompile()` of `BoundaryValueDiffEqFIRK` against `OrdinaryDiffEq#master`'s `DiffEqBase`. With this patch, the MethodError goes away (a separate, unrelated `PreparationMismatchError` from `DifferentiationInterface` remains, which is out of scope for this PR).

Added a regression test in `BoundaryValueDiffEqCore/test/runtests.jl` that calls `_process_verbose_param(DiffEqBase.DEFAULT_VERBOSE)` and asserts the result is a `BVPVerbosity`.

## Test plan

- [x] `Pkg.test()` on `BoundaryValueDiffEqCore` passes locally (includes new regression test)
- [x] Runic check passes on modified files
- [ ] CI

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>