### PR TITLE
Bump all package minor versions to release PR #479 fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.21.0"
+version = "5.22.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

PR #479 merged bug fixes across all sub-libraries plus a SciMLBase compat tightening (dropped the v2 lower bound), but did not bump any package versions. As a result, the `@JuliaRegistrator register` attempts on the merge commit all failed with `Error while trying to register: Version X.Y.Z already exists`.

This PR bumps the minor version of every package so the fixes in #479 can actually be released.

Dropping the `SciMLBase = "2.152.1, 3"` lower bound to `"3"` is a breaking compat change for any downstream consumer that was resolving to the v2 range, so **minor** (not patch) is the appropriate bump.

## Version bumps

| package | from | to |
|---|---|---|
| BoundaryValueDiffEqCore | 2.3.1 | 2.4.0 |
| BoundaryValueDiffEqAscher | 1.13.0 | 1.14.0 |
| BoundaryValueDiffEqFIRK | 1.14.0 | 1.15.0 |
| BoundaryValueDiffEqMIRK | 1.14.0 | 1.15.0 |
| BoundaryValueDiffEqMIRKN | 1.13.0 | 1.14.0 |
| BoundaryValueDiffEqShooting | 1.14.0 | 1.15.0 |
| BoundaryValueDiffEq (top) | 5.21.0 | 5.22.0 |

Inter-sublib compat entries in the sub-library `Project.toml`s pin `BoundaryValueDiffEqCore` by `"2.0"` / `"2.2"`, which already cover Core 2.4, and the top-level `Project.toml` pins sublibs by major only — so no compat edits are needed.

## Release plan (after merge)

Comment on the merge commit of this PR, in this order (Core first, top-level last, so General compat resolves cleanly):

```
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqCore
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqAscher
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqFIRK
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqMIRK
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqMIRKN
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqShooting
@JuliaRegistrator register()
```

## Test plan

- [ ] CI green on master after merge
- [ ] Registrator succeeds for all 7 packages on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)