### PR TITLE
Bump all package minor versions to release PR #481 fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.22.0"
+version = "5.23.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

[PR #481](https://github.com/SciML/BoundaryValueDiffEq.jl/pull/481) widened compat for the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem and made code changes in `BoundaryValueDiffEqCore` (`utils.jl`) and `BoundaryValueDiffEqShooting` (`single_shooting.jl`, `multiple_shooting.jl`), but didn't bump any package versions. This PR bumps minor versions on every package that received compat or code changes so they can be registered.

## Bumps

| package | from | to |
|---|---|---|
| BoundaryValueDiffEqCore     | 2.4.0  | 2.5.0  |
| BoundaryValueDiffEqAscher   | 1.14.0 | 1.15.0 |
| BoundaryValueDiffEqFIRK     | 1.15.0 | 1.16.0 |
| BoundaryValueDiffEqMIRK     | 1.15.0 | 1.16.0 |
| BoundaryValueDiffEqMIRKN    | 1.14.0 | 1.15.0 |
| BoundaryValueDiffEqShooting | 1.15.0 | 1.16.0 |
| BoundaryValueDiffEq (top)   | 5.22.0 | 5.23.0 |

Minor (rather than patch) — dropping/widening compat ranges to admit OrdinaryDiffEq v7 / SciMLBase v3 / DiffEqDevTools v3 isn't strictly a SemVer-patch operation, since downstream consumers may resolve through to different majors than before.

## Test plan

- [ ] CI green on master after merge
- [ ] Re-register all sublibs (Core first, top-level last) on the merge commit; AutoMerge clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)