### PR TITLE
Fix MIRK/FIRK adaptive mesh refinement under RAT v4 (closes #484)

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/test/mirk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/mirk_basic_tests.jl
@@ -712,3 +712,39 @@ end
     sol2 = solve(bvp2, MIRK4(), dt = 0.1, adaptive = false, nlsolve_kwargs = (; maxiters = 0))
     @test sol2.u == u_guess
 end
+
+# https://github.com/SciML/BoundaryValueDiffEq.jl/issues/484
+# Adaptive mesh refinement on a sufficiently nonlinear BVP must not throw
+# UndefRefError. The torus geodesic system is smooth and nonlinear enough
+# that the solver decides to refine the mesh.
+@testitem "Adaptive mesh refinement (issue 484)" begin
+    using BoundaryValueDiffEqMIRK
+
+    R = 3.0
+    r = 2.0
+
+    function f!(du, u, p, t)
+        sinθ, cosθ = sincos(u[1])
+        R_θ = R + r * cosθ
+        du[1] = u[3]
+        du[2] = u[4]
+        du[3] = -u[4]^2 * R_θ * sinθ / r
+        du[4] = 2 * r * sinθ / R_θ * u[3] * u[4]
+    end
+
+    a1 = [0.5, -1.2]
+    a2 = [-0.5, 0.3]
+
+    function bc!(residual, u, p, t)
+        ua = u(0.0)
+        ub = u(1.0)
+        residual[1:2] = ua[1:2] - a1
+        residual[3:4] = ub[1:2] - a2
+    end
+
+    prob = BVProblem(f!, bc!, vcat(a1, zero(a1)), (0.0, 1.0))
+    sol = solve(prob, MIRK4(); dt = 0.05)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1][1:2] ≈ a1 atol = 1.0e-8
+    @test sol.u[end][1:2] ≈ a2 atol = 1.0e-8
+end

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/src/mirkn.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/mirkn.jl
@@ -137,7 +137,7 @@ function SciMLBase.solve!(cache::MIRKNCache{iip, T}) where {iip, T}
 end
 
 function __perform_mirkn_iteration(cache::MIRKNCache)
-    nlprob = __construct_nlproblem(cache, vec(cache.y₀), copy(cache.y₀))
+    nlprob = __construct_nlproblem(cache, copy(vec(cache.y₀)), copy(cache.y₀))
     solve_alg = __concrete_solve_algorithm(nlprob, cache.alg.nlsolve, cache.alg.optimize)
     kwargs = __concrete_kwargs(
         cache.alg.nlsolve, cache.alg.optimize, cache.nlsolve_kwargs, cache.optimize_kwargs,


### PR DESCRIPTION
## Summary

- Closes #484 (`UndefRefError` from MIRK 1.15+ adaptive mesh refinement on nonlinear BVPs).
- Root cause: `__resize!(::AbstractVectorOfArray, n, M)` in `BoundaryValueDiffEqCore/src/utils.jl` (and the FIRK-specific overloads in `BoundaryValueDiffEqFIRK/src/utils.jl`) were missed by the SciMLBase-v3 / RecursiveArrayTools-v4 compat patch (bea82b8). Under RAT v4, `AbstractVectorOfArray` subtypes `AbstractArray` with column-major linear-indexing semantics, so `length(x)` returns the total scalar count and `last(x)` returns the last scalar. The old code used both as if they were the timestep count / last timestep vector, so `N` was miscomputed and the inner `x.u` was never appended to.
- Bumps `BoundaryValueDiffEqCore` patch version to `2.5.1`.
- Adds a regression `@testitem` in `mirk_basic_tests.jl` based on the issue MWE (torus geodesic BVP — smooth and nonlinear enough that the solver decides to refine).

## Diff

```julia
# Before (BoundaryValueDiffEqCore/src/utils.jl)
function __resize!(x::AbstractVectorOfArray, n, M)
    N = n - length(x)                                                                    # ← scalar count under RAT v4
    N == 0 && return x
    N > 0 ? append!(x, VectorOfArray([safe_similar(last(x)) for _ in 1:N])) : resize!(x, n)
                                                #          ^^^^^^^^^^ last scalar under RAT v4
    return x
end

# After
function __resize!(x::AbstractVectorOfArray, n, M)
    N = n - length(x.u)
    N == 0 && return x
    N > 0 ? append!(x.u, [safe_similar(last(x.u)) for _ in 1:N]) : resize!(x, n)
    return x
end
```

Same pattern applied to the FIRK-specific overloads for `FIRKTableau{false}` and `FIRKTableau{true}`. `resize!(x, n)` is left as-is because RAT v4's `Base.resize!(::AbstractVectorOfArray, ::Integer)` already delegates to `resize!(x.u, n)`.

## Local verification

Issue 484 MWE on Julia 1.12.4 with this branch:

```
=== Adaptive (the failing case) ===
retcode: Success  length(sol.u): 41
sol.u[1]: [0.5, -1.2, -0.4865496830944581, 1.5910097544175474]
sol.u[end]: [-0.5, 0.3, -0.4865763588189779, 1.591006957693632]
SUCCESS: adaptive ran without UndefRefError

=== Non-adaptive (the workaround, should still work) ===
retcode: Success  length(sol2.u): 21
SUCCESS: adaptive=false still works
```

## Test plan

- [ ] CI: BoundaryValueDiffEqCore tests pass
- [ ] CI: BoundaryValueDiffEqMIRK tests pass (incl. the new "Adaptive mesh refinement (issue 484)" testitem)
- [ ] CI: BoundaryValueDiffEqFIRK tests pass
- [ ] Manifolds.jl downstream (the original consumer) — they currently work around with `adaptive = false`; once this lands they can drop the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)