### PR TITLE
Bump minor versions for sublibrary releases (Core/MIRK/MIRKN/FIRK/Shooting)

### DIFF
--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
-version = "1.16.0"
+version = "1.17.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
-version = "1.16.0"
+version = "1.17.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.1"
+version = "1.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
-version = "1.16.0"
+version = "1.17.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

Minor-version bumps for the sublibraries that have accumulated source changes since the last bump (`b6513996`, PR #482):

| Package | From | To |
|---|---|---|
| BoundaryValueDiffEqCore | 2.5.0 | **2.6.0** |
| BoundaryValueDiffEqMIRK | 1.16.0 | **1.17.0** |
| BoundaryValueDiffEqMIRKN | 1.15.1 | **1.16.0** |
| BoundaryValueDiffEqFIRK | 1.16.0 | **1.17.0** |
| BoundaryValueDiffEqShooting | 1.16.0 | **1.17.0** |

`BoundaryValueDiffEq` (top-level) and `BoundaryValueDiffEqAscher` are **not** bumped — neither has source changes since their current Project.toml versions.

## Changes bundled per package

- **Core (2.6.0)** — fix lcons/ucons length in `__extract_lcons_ucons` for the optimize path (#473)
- **MIRK (1.17.0)** — RAT global error control fix, RAT mesh selection fix, RAT view fix, initial guess fix, resize fix, type stability, ensemble interface fix, Mooncake 0.5 compat
- **MIRKN (1.16.0)** — nlprob u0 inference fix + #484 regression test (PR #485). Folds in the unreleased 1.15.1 patch and bumps to a clean minor.
- **FIRK (1.17.0)** — Enzyme compat fix, RAT mesh selection fix, resize fix, Mooncake 0.5 compat
- **Shooting (1.17.0)** — initial guess fix in `multiple_shooting`

## Compat impact

All inter-package compat constraints use major-only ranges (`"1"`, `"2"`, `"2.0"`, `"2.2"`), so these minor bumps don't break any sublib's compat. No top-level Project.toml changes required.

## Post-merge

After merge, register each sublib via JuliaRegistrator comments on the merge commit:

```
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqCore
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqMIRK
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqMIRKN
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqFIRK
@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqShooting
```

## Test plan

- [ ] CI green on master (each sublib's CI workflow + Downstream)
- [ ] After merge: comment JuliaRegistrator commands above
- [ ] Confirm registry PRs open and merge
- [ ] TagBot creates the corresponding tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)