### PR TITLE
MIRK: cache the flat nlprob u0 buffer instead of reallocating each iteration

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
@@ -21,6 +21,10 @@
     k_interp                   # Stage information associated with the discrete Runge-Kutta method
     y
     y₀
+    y₀_flat                    # Flat Vector{T} mirror of y₀ used as nlprob u0 to keep
+                               # LinearSolve / NonlinearSolveBase happy (they require a
+                               # concrete `Vector{T}`, not the `Base.ReshapedArray` that
+                               # `vec(::VectorOfArray)` returns under RAT v4).
     residual
     # The following 2 caches are never resized
     fᵢ_cache
@@ -75,6 +79,7 @@ function SciMLBase.__init(
 
     # Don't flatten this here, since we need to expand it later if needed
     y₀ = __initial_guess_on_mesh(prob.u0, mesh, prob.p; tune_parameters = tune_parameters)
+    y₀_flat = collect(vec(y₀))
 
     y = __alloc.(copy.(y₀.u))
     TU, ITU = constructMIRK(alg, T)
@@ -235,7 +240,7 @@ function SciMLBase.__init(
     return MIRKCache{iip, T, use_both, typeof(diffcache), tune_parameters}(
         alg_order(alg), stage, N, size(u0), f, bc, prob_, prob.problem_type, prob.p, alg,
         TU, ITU, f_prototype, bcresid_prototype, mesh, mesh_dt, k_discrete, k_interp, y,
-        y₀, residual, fᵢ_cache, fᵢ₂_cache, errors, new_stages, resid₁_size, prob.singular_term
+        y₀, y₀_flat, residual, fᵢ_cache, fᵢ₂_cache, errors, new_stages, resid₁_size, prob.singular_term
         , nlsolve_kwargs, optimize_kwargs, (; abstol, dt, adaptive, controller, tune_parameters, kwargs...), verbose_spec
     )
 end
@@ -252,6 +257,7 @@ function __expand_cache!(cache::MIRKCache{iip, T, use_both}) where {iip, T, use_
     __resize!(cache.k_interp.u, Nₙ - 1, cache.M)
     __resize!(cache.y, Nₙ, cache.M)
     __resize!(cache.y₀.u, Nₙ, cache.M)
+    resize!(cache.y₀_flat, Nₙ * cache.M)
     __resize!(cache.residual, Nₙ, cache.M)
     __resize!(cache.errors.u, ifelse(use_both, 2 * (Nₙ - 1), (Nₙ - 1)), cache.M)
     __resize!(cache.new_stages.u, Nₙ - 1, cache.M)
@@ -307,7 +313,10 @@ function SciMLBase.solve!(
 end
 
 function __perform_mirk_iteration(cache::MIRKCache, abstol, adaptive::Bool, controller::AbstractErrorControl)
-    nlprob = __construct_problem(cache, copy(vec(cache.y₀)), copy(cache.y₀))
+    # Refresh the flat mirror from the structured guess (in-place; no fresh allocation
+    # per outer iteration). NonlinearSolve / LinearSolve still see a `Vector{T}`.
+    copyto!(cache.y₀_flat, vec(cache.y₀))
+    nlprob = __construct_problem(cache, cache.y₀_flat, copy(cache.y₀))
     solve_alg = __concrete_solve_algorithm(nlprob, cache.alg.nlsolve, cache.alg.optimize)
     kwargs = __concrete_kwargs(
         cache.alg.nlsolve, cache.alg.optimize, cache.nlsolve_kwargs, cache.optimize_kwargs,


### PR DESCRIPTION
Partial step toward #486.

## What

`__perform_mirk_iteration` previously called

```julia
nlprob = __construct_problem(cache, copy(vec(cache.y₀)), copy(cache.y₀))
```

The `copy(vec(cache.y₀))` allocated a fresh `Vector{T}` every outer mesh-refinement step purely to materialize the flat representation NonlinearSolve / LinearSolve require — `vec(::VectorOfArray)` under RAT v4 returns a `Base.ReshapedArray`, which `LinearSolve.LinearCache`'s declared `Vector{T}` field doesn't accept.

This PR adds a `y₀_flat::Vector{T}` field on `MIRKCache` that mirrors `cache.y₀`:

- allocated once in `__init` via `collect(vec(y₀))`,
- kept in sync with the mesh in `__expand_cache!` via `resize!(cache.y₀_flat, Nₙ * cache.M)`,
- refreshed in place via `copyto!(cache.y₀_flat, vec(cache.y₀))` at the start of each outer iteration.

The flat mirror is then handed to `__construct_problem` as the nlprob `u0`, so NonlinearSolve / LinearSolve still see a concrete `Vector{T}` and the per-outer-iteration allocation disappears.

## Why this PR is the minimal step toward #486

[#486](https://github.com/SciML/BoundaryValueDiffEq.jl/issues/486) proposes passing `cache.y₀::VectorOfArray` directly through to NonlinearSolve and dropping the `recursive_unflatten!` / `recursive_flatten!` round-trips inside the `__mirk_loss!` family altogether. I tried that end-to-end on MIRK and it fails inside MIRK's own `@compile_workload`: NonlinearSolve / LinearSolve internally call `vec(u_voa)`, get a `Base.ReshapedArray{Float64, 1, VectorOfArray{…}, …}`, and `setproperty!` on a `LinearSolve.LinearCache{…, Vector{Float64}, Vector{Float64}, …}` rejects it (write-up in [#486 comment](https://github.com/SciML/BoundaryValueDiffEq.jl/issues/486#issuecomment-4360772554)).

The deeper refactor needs upstream changes first — either widening `LinearSolve.LinearCache`'s `b`/`u` typing from `Vector{T}` to `AbstractVector{T}`, or changing what `vec(::VOA)` returns. This PR is the part that's safe to land in BVDE alone right now: the `Vector{T}` interface to NonlinearSolve / LinearSolve is preserved, but we no longer pay an allocation per outer iteration to construct it.

FIRK and MIRKN can get the same treatment in follow-ups; same fix applies.

## Test plan

- [x] `Pkg.test()` for `BoundaryValueDiffEqMIRK` passes — 25/25 test items, 308/308 tests, ~72 min wall-clock on Julia 1.12.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)