### PR TITLE
ci: uniformize onto centralized CI (project-model SublibraryCI + cleanup)

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,17 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  doc-preview-cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -26,10 +26,16 @@ jobs:
       - name: "List lib/* sublibraries"
         id: list
         run: |
-          # jq is preinstalled on GitHub-hosted runners; -R reads each path as a
-          # JSON string, -s slurps them into a compact array (-> [] when empty).
-          projects=$(for d in lib/*/; do d="${d%/}"; [ -f "$d/Project.toml" ] && echo "$d"; done \
-            | jq -R . | jq -sc .)
+          # Build the JSON array in pure shell -- no jq/python3, since neither is
+          # guaranteed on a self-hosted runner. lib/* names contain no JSON-special
+          # characters, so plain quoting is safe.
+          projects=""
+          for d in lib/*/; do
+            d="${d%/}"
+            [ -f "$d/Project.toml" ] || continue
+            if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
+          done
+          projects="[$projects]"
           echo "Sublibraries: $projects"
           echo "projects=$projects" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -41,5 +41,7 @@ jobs:
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       project: "${{ matrix.project }}"
-      coverage: false
+      # collect the sublibrary's own source coverage (its tests are the only thing
+      # that exercises it); point processcoverage at the sublibrary, not repo root.
+      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
     secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -17,39 +17,6 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  list-sublibraries:
-    runs-on: ubuntu-latest
-    outputs:
-      projects: ${{ steps.list.outputs.projects }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: "List lib/* sublibraries"
-        id: list
-        run: |
-          # Build the JSON array in pure shell -- no jq/python3, since neither is
-          # guaranteed on a self-hosted runner. lib/* names contain no JSON-special
-          # characters, so plain quoting is safe.
-          projects=""
-          for d in lib/*/; do
-            d="${d%/}"
-            [ -f "$d/Project.toml" ] || continue
-            if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
-          done
-          projects="[$projects]"
-          echo "Sublibraries: $projects"
-          echo "projects=$projects" >> "$GITHUB_OUTPUT"
-
-  test:
-    needs: list-sublibraries
-    strategy:
-      fail-fast: false
-      matrix:
-        project: ${{ fromJson(needs.list-sublibraries.outputs.projects) }}
-    name: "Sublibrary - ${{ matrix.project }}"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      project: "${{ matrix.project }}"
-      # collect the sublibrary's own source coverage (its tests are the only thing
-      # that exercises it); point processcoverage at the sublibrary, not repo root.
-      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+  sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -26,8 +26,10 @@ jobs:
       - name: "List lib/* sublibraries"
         id: list
         run: |
+          # jq is preinstalled on GitHub-hosted runners; -R reads each path as a
+          # JSON string, -s slurps them into a compact array (-> [] when empty).
           projects=$(for d in lib/*/; do d="${d%/}"; [ -f "$d/Project.toml" ] && echo "$d"; done \
-            | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+            | jq -R . | jq -sc .)
           echo "Sublibraries: $projects"
           echo "projects=$projects" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -1,4 +1,4 @@
-name: "Sublibrary CI"
+name: Sublibrary CI
 
 on:
   pull_request:
@@ -17,7 +17,29 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  sublibrary-ci:
-    name: "Sublibrary CI"
-    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+  list-sublibraries:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.list.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: "List lib/* sublibraries"
+        id: list
+        run: |
+          projects=$(for d in lib/*/; do d="${d%/}"; [ -f "$d/Project.toml" ] && echo "$d"; done \
+            | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+          echo "Sublibraries: $projects"
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: list-sublibraries
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.list-sublibraries.outputs.projects) }}
+    name: "Sublibrary - ${{ matrix.project }}"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "${{ matrix.project }}"
+      coverage: false
     secrets: "inherit"


### PR DESCRIPTION
Uniformizes this repo onto the centralized CI setup released in SciML/.github `@v1`:

- Migrate SublibraryCI to the project-model `sublibrary-project-tests.yml@v1`
- Add `DocPreviewCleanup.yml` → `docs-preview-cleanup.yml@v1`

**Deliberately excluded:** TagBot centralization (the reusable `tagbot.yml` only wraps `JuliaRegistries/TagBot@v1`, which already floats — near-zero value, and rewriting the sublib matrix risks silently dropping a package from registration); `dependabot-automerge` / `runic-suggestions` (opt-in behavior changes).

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)