### PR TITLE
style: apply Runic v1.7.0 formatting

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
@@ -22,9 +22,9 @@
     y
     y₀
     y₀_flat                    # Flat Vector{T} mirror of y₀ used as nlprob u0 to keep
-                               # LinearSolve / NonlinearSolveBase happy (they require a
-                               # concrete `Vector{T}`, not the `Base.ReshapedArray` that
-                               # `vec(::VectorOfArray)` returns under RAT v4).
+    # LinearSolve / NonlinearSolveBase happy (they require a
+    # concrete `Vector{T}`, not the `Base.ReshapedArray` that
+    # `vec(::VectorOfArray)` returns under RAT v4).
     residual
     # The following 2 caches are never resized
     fᵢ_cache


### PR DESCRIPTION
## Summary

The Runic Format Check (CI `format-check` job, which uses `SciML/.github` `runic.yml@v1` → `fredrikekre/runic-action@v1` = **Runic v1.7.0**) was failing because some code was not conformant to that exact Runic version.

This PR fixes that by running **Runic v1.7.0 in-place over the whole repo** (all tracked `.jl` files, including `lib/` sublibraries) and committing the result.

## Details

- **Pure formatting only.** No logic changes, no changes to non-`.jl` files, no CI/Project.toml changes.
- Only one file actually drifted: `lib/BoundaryValueDiffEqMIRK/src/mirk.jl` (re-indentation of a multi-line trailing comment in a struct field block).
- Verified afterwards that a Runic v1.7.0 `--check` pass reports **no remaining diffs** across all 110 tracked `.jl` files.

This is intentionally a separate, self-contained formatting PR so it can be reviewed and merged independently.

---

**Please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)