### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,67 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
-    permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        # Root BoundaryValueDiffEq's own test groups only. The lib/* sublibraries
-        # are covered by SublibraryCI.yml (project model); do not double-test them
-        # through the root matrix.
-        group:
-          - Misc
-          - Wrappers
-          - QA
-        version:
-          - 'lts'
-          - '1'
-          - 'pre'
-        exclude:
-          # QA (Aqua + JET) runs on release + LTS Julia only (not pre-release).
-          - group: QA
-            version: 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
-      - name: Develop local path deps (Julia < 1.11)
-        shell: julia --color=yes --project=. {0}
-        run: |
-          using Pkg
-          if VERSION < v"1.11.0-DEV.0"
-            toml = Pkg.TOML.parsefile("Project.toml")
-            if haskey(toml, "sources")
-              specs = Pkg.PackageSpec[]
-              for (dep, spec) in toml["sources"]
-                if spec isa Dict && haskey(spec, "path") && isdir(spec["path"])
-                  @info "Developing" dep spec["path"]
-                  push!(specs, Pkg.PackageSpec(path=spec["path"]))
-                end
-              end
-              # Batch the develop call so Pkg resolves all path deps together.
-              isempty(specs) || Pkg.develop(specs)
-            end
-          end
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: true
-          check_bounds: auto
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,ext
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: false
-          disable_safe_directory: true
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
+    with:
+      check-bounds: auto
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

Converts the root `CI.yml` test workflow to the new reusable `SciML/.github/.github/workflows/grouped-tests.yml@v1` thin caller. The previously hand-maintained `group × version` matrix embedded in the `test` job is now declared once in `test/test_groups.toml` (which already existed from the monorepo uniformization and reproduces the matrix exactly) and computed by `compute_affected_sublibraries.jl --root-matrix`.

The workflow's `name: CI`, `on:` triggers, and `concurrency:` block are preserved verbatim so the branch-protection status-check name is unchanged. `SublibraryCI.yml` (the `sublibrary-project-tests.yml@v1` caller) is untouched.

## `with:` inputs

Only the previous job's non-default setting is carried over:

- `check-bounds: auto` (old job set `check_bounds: auto`).

Everything else matches the reusable workflow defaults, so no other inputs are needed:

- group env var: `GROUP` (default) — root `runtests.jl` reads `get(ENV, "GROUP", "All")`.
- `coverage`: default `true` (old job had `coverage: true`).
- `coverage-directories`: default `src,ext` (old job's `directories: src,ext`).

## Verified matrix match

Ran `compute_affected_sublibraries.jl . --root-matrix` against the repo and compared the emitted `(group, version)` set to the old `CI.yml` matrix (`Misc/Wrappers/QA × {lts,1,pre}` minus `QA×pre`):

```
OLD (8): Misc{lts,1,pre}, Wrappers{lts,1,pre}, QA{lts,1}
NEW (8): Misc{lts,1,pre}, Wrappers{lts,1,pre}, QA{lts,1}
MATCH 8/8  (0 missing, 0 extra)
```

All per-job specials (runner, timeout, num_threads, continue_on_error) resolve to defaults, matching the old single-OS `ubuntu-latest` / `timeout-minutes: 120` job.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)