### PR TITLE
Apply Runic formatting to test runtests.jl files

### DIFF
--- a/lib/BoundaryValueDiffEqAscher/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqAscher/test/runtests.jl
@@ -10,10 +10,12 @@ function activate_qa_env()
     # On Julia < 1.11, the [sources] section in Project.toml is not honored.
     # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
     if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop([
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
-        ])
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
+            ]
+        )
     end
     return Pkg.instantiate()
 end

--- a/lib/BoundaryValueDiffEqFIRK/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/runtests.jl
@@ -10,10 +10,12 @@ function activate_qa_env()
     # On Julia < 1.11, the [sources] section in Project.toml is not honored.
     # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
     if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop([
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
-        ])
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
+            ]
+        )
     end
     return Pkg.instantiate()
 end

--- a/lib/BoundaryValueDiffEqMIRK/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/runtests.jl
@@ -10,10 +10,12 @@ function activate_qa_env()
     # On Julia < 1.11, the [sources] section in Project.toml is not honored.
     # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
     if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop([
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
-        ])
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
+            ]
+        )
     end
     return Pkg.instantiate()
 end

--- a/lib/BoundaryValueDiffEqMIRKN/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/test/runtests.jl
@@ -10,10 +10,12 @@ function activate_qa_env()
     # On Julia < 1.11, the [sources] section in Project.toml is not honored.
     # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
     if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop([
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
-        ])
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
+            ]
+        )
     end
     return Pkg.instantiate()
 end

--- a/lib/BoundaryValueDiffEqShooting/test/runtests.jl
+++ b/lib/BoundaryValueDiffEqShooting/test/runtests.jl
@@ -10,10 +10,12 @@ function activate_qa_env()
     # On Julia < 1.11, the [sources] section in Project.toml is not honored.
     # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
     if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop([
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
-            Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
-        ])
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "BoundaryValueDiffEqCore"))
+            ]
+        )
     end
     return Pkg.instantiate()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,15 +12,17 @@ function develop_local_path_deps()
     # the sub-environment tests the PR branch code.
     repo_root = dirname(@__DIR__)
     lib = joinpath(repo_root, "lib")
-    return Pkg.develop([
-        Pkg.PackageSpec(path = repo_root),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqAscher")),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqCore")),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqFIRK")),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqMIRK")),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqMIRKN")),
-        Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqShooting"))
-    ])
+    return Pkg.develop(
+        [
+            Pkg.PackageSpec(path = repo_root),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqAscher")),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqCore")),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqFIRK")),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqMIRK")),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqMIRKN")),
+            Pkg.PackageSpec(path = joinpath(lib, "BoundaryValueDiffEqShooting")),
+        ]
+    )
 end
 
 function activate_qa_env()


### PR DESCRIPTION
## Summary

Fixes the failing `format-check` (Runic) workflow on master. The six `runtests.jl` files touched by the monorepo-structure uniformization (#505) were not Runic-formatted:

- `lib/BoundaryValueDiffEq{Ascher,FIRK,MIRK,MIRKN,Shooting}/test/runtests.jl`
- `test/runtests.jl`

format-check has been red on master since commit 97e8de71 / f86a8c84-era pushes (first red run: 2026-06-05, consistently red since #505 merged).

Pure formatting change produced by `Runic.main(["--inplace", "."])`; verified locally that `Runic.main(["--check", "."])` now exits 0 and all six files still parse.

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)