### PR TITLE
Work around ODEInterface solver loading failure on Julia 1.12+

### DIFF
--- a/ext/BoundaryValueDiffEqODEInterfaceExt.jl
+++ b/ext/BoundaryValueDiffEqODEInterfaceExt.jl
@@ -5,6 +5,7 @@ using BoundaryValueDiffEqCore: __extract_u0, __initial_guess_length, __extract_m
     __flatten_initial_guess, __get_bcresid_prototype,
     __has_initial_guess, __initial_guess, _process_verbose_param, BVPVerbosity, @SciMLMessage
 using SciMLBase: SciMLBase, BVProblem, TwoPointBVProblem, ReturnCode
+using ODEInterface: ODEInterface
 using ODEInterface: OptionsODE, OPT_ATOL, OPT_RTOL, OPT_METHODCHOICE, OPT_DIAGNOSTICOUTPUT,
     OPT_ERRORCONTROL, OPT_SINGULARTERM, OPT_MAXSTEPS, OPT_BVPCLASS,
     OPT_SOLMETHOD, OPT_RHS_CALLMODE, OPT_COLLOCATIONPTS, OPT_ADDGRIDPOINTS,
@@ -15,6 +16,19 @@ using ODEInterface: colnew
 
 using FastClosures: @closure
 using ForwardDiff: ForwardDiff
+
+function __init__()
+    # ODEInterface.loadODESolvers does `@eval using ODEInterface_jll` and then
+    # reads bindings from that module within the same world age. Under the
+    # Julia 1.12 binding world-age semantics the new binding is not visible
+    # yet, so every solver records an UndefVarError(:ODEInterface_jll) on the
+    # first call. Failed solvers are retried on later calls, and a second call
+    # in a newer world (via invokelatest) resolves the binding and loads all
+    # solvers. Harmless no-op on older Julia where the first call succeeds.
+    ODEInterface.loadODESolvers()
+    Base.invokelatest(ODEInterface.loadODESolvers)
+    return nothing
+end
 
 #------
 # BVPM2


### PR DESCRIPTION
## Summary

Fixes the `Wrappers` test group failures on master CI (julia `1` and `pre`; run 27135552430): the BVPSOL testset errored with

```
Cannot find method(s) for bvpsol! I've tried to loadODESolvers(), but it didn't work.
caused by: AssertionError: (dlSolversInfo[dlname]).error === nothing
```

## Root cause (upstream ODEInterface.jl bug on Julia 1.12+)

`ODEInterface.loadODESolvers` does `@eval ODEInterface begin using ODEInterface_jll end` and then reads bindings from that module **in the same world age**. Under Julia 1.12's binding world-age semantics the new binding is not visible yet, so on the first call *every* solver records `UndefVarError(:ODEInterface_jll)`:

```
julia> res = ODEInterface.loadODESolvers();  # Julia 1.12.6
FAILED: bvpsol => UndefVarError(:ODEInterface_jll, ...)
... (23 failures, all solvers)
julia> res2 = ODEInterface.loadODESolvers();  # second call, new world
# 0 failures
```

Failed solvers are retried on later calls, so a second call in a newer world succeeds. This also explains why COLNEW tests passed on CI while BVPSOL failed (the failed first attempt happened inside BVPSOL's `getAllMethodPtrs`, bumping the world for the later COLNEW calls), and why `lts` (1.10) is unaffected.

## Fix

Add an `__init__` to `BoundaryValueDiffEqODEInterfaceExt` that calls `loadODESolvers()` once (triggering the `using`) and then again via `Base.invokelatest` (loading the solvers in the new world). Harmless no-op on older Julia where the first call already succeeds.

The real fix belongs upstream in [luchr/ODEInterface.jl](https://github.com/luchr/ODEInterface.jl) (`loadODESolvers` should use `invokelatest` after its `@eval using`).

## Verification

Ran `test/wrappers/odeinterface_tests.jl` locally on Julia 1.12.6 with this patch:

```
Test Summary: | Pass  Total   Time
BVPSOL        |    4      4  36.5s
Test Summary: | Pass  Total  Time
COLNEW        |    1      1  5.4s
Test Summary:               | Pass  Total  Time
COLNEW for multi-points BVP |    1      1  1.7s
```

Without the patch, BVPSOL errors exactly as on CI.

Note: the remaining `Misc` group failures on master are a separate regression from LinearSolve v3.85 (issue to follow) and are not addressed here.

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)