### PR TITLE
Import Tsit5 in default_solvers test

### DIFF
--- a/test/misc/default_solvers.jl
+++ b/test/misc/default_solvers.jl
@@ -3,6 +3,7 @@ using Test
 
 @testset "Default Solvers" begin
     using BoundaryValueDiffEq, Test
+    using OrdinaryDiffEqTsit5: Tsit5
 
     function f(du, u, p, t)
         (x, v) = u


### PR DESCRIPTION
## Summary

`test/misc/default_solvers.jl` uses `Tsit5` but only does `using BoundaryValueDiffEq`, which does not export it (verified: `isdefined(Main, :Tsit5)` is `false` after `using BoundaryValueDiffEq`). The file therefore fails with `UndefVarError: Tsit5 not defined` whenever it actually executes.

Why this was never seen before: the old ReTestItems-based root CI never collected this file — the last green master run (96658824) executed 13 test items and "Default Solvers" was not among them. #505 added the file to the `Misc` group, after which:
- the **Downgrade** workflow fails with exactly this `UndefVarError` (run 27135552367, after the BigFloat tests pass there with old deps);
- in the **Misc** group the error is currently masked because the BigFloat safetestset (LinearSolve v3.85 regression, #509) aborts the run before this file is reached. Once #509 is resolved, Misc would hit this error.

Fix: `using OrdinaryDiffEqTsit5: Tsit5` inside the testset. `OrdinaryDiffEqTsit5` is already in the test target of the root Project.toml.

## Verification

Ran the patched file locally on Julia 1.12.6 against a clean master checkout:

```
Test Summary:   | Pass  Total   Time
Default Solvers |    2      2  12.2s
```

Runic check passes on the changed file.

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)