### PR TITLE
Don't embed initial-guess object types in collocation caches (fix 20x compile-time regression)

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/src/firk.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/firk.jl
@@ -257,7 +257,16 @@ function init_nested(
         vecf, vecbc
     end
 
-    prob_ = !(prob.u0 isa AbstractArray) ? remake(prob; u0 = u0) : prob
+    # Initial guess objects (`ODESolution`, `VectorOfArray`, functions, ...) must be
+    # stripped down to the extracted `u0` vector here: under RecursiveArrayTools v4
+    # `AbstractVectorOfArray <: AbstractArray`, so a plain `isa AbstractArray` check
+    # would embed e.g. an entire previous solution's type in the cache and force
+    # recompilation of all downstream code against it (issue #500).
+    prob_ = if !(prob.u0 isa AbstractArray) || prob.u0 isa AbstractVectorOfArray
+        remake(prob; u0 = u0)
+    else
+        prob
+    end
 
     # Somewhat arbitrary initialization of K
     K0 = __K0_on_u0(prob, stage; tune_parameters = tune_parameters)
@@ -424,7 +433,16 @@ function init_expanded(
         vecf, vecbc
     end
 
-    prob_ = !(prob.u0 isa AbstractArray) ? remake(prob; u0 = u0) : prob
+    # Initial guess objects (`ODESolution`, `VectorOfArray`, functions, ...) must be
+    # stripped down to the extracted `u0` vector here: under RecursiveArrayTools v4
+    # `AbstractVectorOfArray <: AbstractArray`, so a plain `isa AbstractArray` check
+    # would embed e.g. an entire previous solution's type in the cache and force
+    # recompilation of all downstream code against it (issue #500).
+    prob_ = if !(prob.u0 isa AbstractArray) || prob.u0 isa AbstractVectorOfArray
+        remake(prob; u0 = u0)
+    else
+        prob
+    end
 
     return FIRKCacheExpand{iip, T, typeof(diffcache), tune_parameters}(
         alg_order(alg), stage, M, size(u0), f, bc, prob_, prob.problem_type, prob.p,

--- a/lib/BoundaryValueDiffEqFIRK/test/expanded/firk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/expanded/firk_basic_tests.jl
@@ -566,3 +566,42 @@ end
     @test bvp2.u0 == u_guess
 end
 =#
+
+# https://github.com/SciML/BoundaryValueDiffEq.jl/issues/500
+# An initial-guess object (previous solution, VectorOfArray, ...) must be
+# stripped to a plain vector before being stored in the cache's problem.
+# Under RecursiveArrayTools v4 solutions are `AbstractArray`s, so without the
+# explicit strip the entire solution type gets embedded in the cache type and
+# every downstream method recompiles against it (~20x compile-time blowup).
+@testset "Initial-guess object does not leak into cache type (issue 500)" begin
+    using SciMLBase, RecursiveArrayTools
+
+    tspan = (0.0, 1.0)
+    function f!(du, u, p, t)
+        du[1] = -u[2] / p[1]
+        du[2] = p[2]
+        du[3] = 0.0
+    end
+    function bca!(res_a, u_a, p)
+        res_a[1] = u_a[2]
+        res_a[2] = u_a[1] - 100.0
+    end
+    function bcb!(res_b, u_b, p)
+        res_b[1] = u_b[3] * (u_b[1] - 20.0) - u_b[2]
+    end
+    u_guess = [[100.0 - 0.5 * i, 0.02 * i, 0.006666666666666668] for i in 0:10]
+    p = [0.002, 0.2]
+    bvp1 = TwoPointBVProblem(
+        f!, (bca!, bcb!), u_guess, tspan, p; bcresid_prototype = (zeros(2), zeros(1))
+    )
+    sol1 = solve(bvp1, RadauIIa5(), dt = 0.1, adaptive = false)
+    @test SciMLBase.successful_retcode(sol1)
+
+    bvp2 = remake(bvp1, p = [0.0015, 0.03], u0 = sol1)
+    for nested in (true, false)
+        cache = init(bvp2, RadauIIa5(; nested_nlsolve = nested), dt = 0.1, adaptive = false)
+        @test cache.prob.u0 isa Vector{Float64}
+    end
+    sol2 = solve(bvp2, RadauIIa5(), dt = 0.1, adaptive = false)
+    @test SciMLBase.successful_retcode(sol2)
+end

--- a/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
@@ -235,7 +235,16 @@ function SciMLBase.__init(
         vecf, vecbc
     end
 
-    prob_ = !(prob.u0 isa AbstractArray) ? remake(prob; u0 = u0) : prob
+    # Initial guess objects (`ODESolution`, `VectorOfArray`, functions, ...) must be
+    # stripped down to the extracted `u0` vector here: under RecursiveArrayTools v4
+    # `AbstractVectorOfArray <: AbstractArray`, so a plain `isa AbstractArray` check
+    # would embed e.g. an entire previous solution's type in the cache and force
+    # recompilation of all downstream code against it (issue #500).
+    prob_ = if !(prob.u0 isa AbstractArray) || prob.u0 isa AbstractVectorOfArray
+        remake(prob; u0 = u0)
+    else
+        prob
+    end
 
     return MIRKCache{iip, T, use_both, typeof(diffcache), tune_parameters}(
         alg_order(alg), stage, N, size(u0), f, bc, prob_, prob.problem_type, prob.p, alg,

--- a/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
@@ -382,7 +382,7 @@ end
 
 @testset "Compatibility with StaticArrays" begin
     using StaticArrays
-    const g = 9.81
+    g = 9.81
     L = 1.0
     tspan = (0.0, pi / 2)
     function simplependulum!(du, u, p, t)

--- a/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
@@ -750,3 +750,46 @@ end
     @test sol.u[1][1:2] ≈ a1 atol = 1.0e-8
     @test sol.u[end][1:2] ≈ a2 atol = 1.0e-8
 end
+
+# https://github.com/SciML/BoundaryValueDiffEq.jl/issues/500
+# An initial-guess object (previous solution, VectorOfArray, ...) must be
+# stripped to a plain vector before being stored in the cache's problem.
+# Under RecursiveArrayTools v4 solutions are `AbstractArray`s, so without the
+# explicit strip the entire solution type gets embedded in the cache type and
+# every downstream method recompiles against it (~20x compile-time blowup).
+@testset "Initial-guess object does not leak into cache type (issue 500)" begin
+    using SciMLBase, RecursiveArrayTools
+
+    tspan = (0.0, 1.0)
+    function f!(du, u, p, t)
+        du[1] = -u[2] / p[1]
+        du[2] = p[2]
+        du[3] = 0.0
+    end
+    function bca!(res_a, u_a, p)
+        res_a[1] = u_a[2]
+        res_a[2] = u_a[1] - 100.0
+    end
+    function bcb!(res_b, u_b, p)
+        res_b[1] = u_b[3] * (u_b[1] - 20.0) - u_b[2]
+    end
+    u_guess = [[100.0 - 0.5 * i, 0.02 * i, 0.006666666666666668] for i in 0:10]
+    p = [0.002, 0.2]
+    bvp1 = TwoPointBVProblem(
+        f!, (bca!, bcb!), u_guess, tspan, p; bcresid_prototype = (zeros(2), zeros(1))
+    )
+    sol1 = solve(bvp1, MIRK5(), dt = 0.1, adaptive = false)
+    @test SciMLBase.successful_retcode(sol1)
+
+    bvp2 = remake(bvp1, p = [0.0015, 0.03], u0 = sol1)
+    cache = init(bvp2, MIRK5(), dt = 0.1, adaptive = false)
+    @test cache.prob.u0 isa Vector{Float64}
+    sol2 = solve(bvp2, MIRK5(), dt = 0.1, adaptive = false)
+    @test SciMLBase.successful_retcode(sol2)
+
+    bvp3 = remake(bvp1, u0 = VectorOfArray(u_guess))
+    cache = init(bvp3, MIRK5(), dt = 0.1, adaptive = false)
+    @test cache.prob.u0 isa Vector{Float64}
+    sol3 = solve(bvp3, MIRK5(), dt = 0.1, adaptive = false)
+    @test SciMLBase.successful_retcode(sol3)
+end

--- a/lib/BoundaryValueDiffEqMIRKN/src/mirkn.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/mirkn.jl
@@ -113,7 +113,16 @@ function SciMLBase.__init(
         vecf, vecbc
     end
 
-    prob_ = !(prob.u0 isa AbstractArray) ? remake(prob; u0 = u0) : prob
+    # Initial guess objects (`ODESolution`, `VectorOfArray`, functions, ...) must be
+    # stripped down to the extracted `u0` vector here: under RecursiveArrayTools v4
+    # `AbstractVectorOfArray <: AbstractArray`, so a plain `isa AbstractArray` check
+    # would embed e.g. an entire previous solution's type in the cache and force
+    # recompilation of all downstream code against it (issue #500).
+    prob_ = if !(prob.u0 isa AbstractArray) || prob.u0 isa AbstractVectorOfArray
+        remake(prob; u0 = u0)
+    else
+        prob
+    end
 
     return MIRKNCache{iip, T}(
         alg_order(alg), stage, M, size(u0), f, bc, prob_, prob.problem_type,


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Fixes #500.

## Problem

Since the SciMLBase v3 / RecursiveArrayTools v4 ecosystem update (BoundaryValueDiffEq v5.23.0), solving a BVP whose `u0` is a previous solution (the standard warm-start pattern via `remake(prob, u0 = sol)`) became ~20x slower, with `@time` reporting ~100% compilation on every fresh session.

## Root cause

All collocation `__init` methods stored the problem in the cache via

```julia
prob_ = !(prob.u0 isa AbstractArray) ? remake(prob; u0 = u0) : prob
```

Under RAT v3 / SciMLBase v2, `ODESolution` was **not** an `AbstractArray`, so the cache got a problem remade with the extracted plain-vector `u0`. Under RAT v4, `AbstractVectorOfArray <: AbstractArray` (and `ODESolution <: AbstractVectorOfArray`), so the gate flipped: the full solution type stayed embedded in `cache.prob`. Measured with the issue's MRE, `typeof(cache.prob.u0)` went from `Vector{Float64}` (15 chars) to the entire previous solution type (~79,000 chars, which itself nests the previous solve's whole cache type). Every loss closure, DI jacobian preparation, and NonlinearSolve specialization then compiles against that type.

## Fix

Gate on `AbstractVectorOfArray` explicitly in MIRK, FIRK (expand + nested), and MIRKN, so initial-guess objects (previous solutions, `VectorOfArray`/`DiffEqArray`, functions) are always stripped to the extracted `u0` vector — i.e. restore the exact RAT v3-era semantics. (Ascher never had the remake and is unchanged; it predates this regression.)

## Timings (issue MRE, Julia 1.12.6, second solve with solution-object u0, fresh session)

| configuration | second solve |
|---|---|
| BoundaryValueDiffEq v5.21.0 (last good) | 20.2 s |
| BoundaryValueDiffEqMIRK v1.17.0 released | **272.9 s** (100% compilation) |
| this patch | **18.0 s** |

Identical numerical results in all configurations (`sol2.u[1] = [100.0, 3.6e-17, 0.000428...]`).

## Tests

- New regression testsets in MIRK and FIRK basic tests assert `init(prob, alg, ...).prob.u0 isa Vector{Float64}` when `u0` is an `ODESolution` or `VectorOfArray`, plus successful solves. These are deterministic type checks, not timing tests.
- Includes a separate one-line commit fixing `const g = 9.81` inside the MIRK "Compatibility with StaticArrays" `@testset` — a local-scope `const`, which is a lowering error that aborted inclusion of `mirk_basic_tests.jl` at that expression, silently skipping that testset and everything after it. Latent on master; surfaced because the new regression test (appended after it) never ran until it was fixed. (Sublibrary CI has been path-filtering around these tests.)

## Local verification (Julia 1.12.6)

- `Pkg.test("BoundaryValueDiffEqMIRK")`: **all green** — Basic 200/200 (incl. previously-dark testsets after the `const` fix), NLLS 72/72, Ensemble 10/10, AD 9/9, Singular 8/8, VectorOfVector 2/2, DynOpt 2/2, QA 11/11.
- `Pkg.test("BoundaryValueDiffEqMIRKN")`: all green (25/25 + QA 11/11).
- `Pkg.test("BoundaryValueDiffEqFIRK")`: new regression testset 4/4; suite shows 2 fail + 3 "Unexpected Pass" in pre-existing "Convergence on Linear" stage-4/5 checks for problems 9/10 — dependency-stack drift unrelated to this PR (these run a plain `Vector{Float64}` u0 path this PR provably does not touch); documented in https://github.com/SciML/BoundaryValueDiffEq.jl/issues/509#issuecomment-4666517101.
- Runic run on all changed files.

## Process notes

Investigation: reproduced the issue MRE against pinned v5.21.0 / v5.23.0 environments, measured `typeof(cache.prob.u0)` string lengths to locate the type-nesting blowup, confirmed `ODESolution <: AbstractArray` flipped false→true across the RAT v3→v4 boundary while `<: AbstractVectorOfArray` is true on both, then patched the four gate sites and re-verified the MRE end-to-end. Pre-existing master CI failures found along the way (Misc/Wrappers/format/Downgrade groups) were handled separately: PRs #507, #508, #510 and issues #509 + SciML/LinearSolve.jl#1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)