### PR TITLE
Release 6 subpackage(s)

### DIFF
--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.0"
+version = "2.7.1"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Automated subpackage release bumps:
- BoundaryValueDiffEqAscher v1.15.1
- BoundaryValueDiffEqCore v2.7.1
- BoundaryValueDiffEqFIRK v1.17.1
- BoundaryValueDiffEqMIRK v1.17.1
- BoundaryValueDiffEqMIRKN v1.16.1
- BoundaryValueDiffEqShooting v1.17.1