### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.1"
+version = "1.17.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -43,7 +43,7 @@ FastClosures = "0.3.2"
 ForwardDiff = "0.10.38, 1"
 LinearAlgebra = "1.10"
 LinearSolve = "2.36.2, 3"
-Mooncake = "0.4.146, 0.5"
+Mooncake = "0.5.36"
 OrdinaryDiffEqRosenbrock = "1.15.1, 2"
 PreallocationTools = "1.2"
 PrecompileTools = "1.2"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.1"
+version = "1.17.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -41,7 +41,7 @@ FastClosures = "0.3.2"
 ForwardDiff = "0.10.38, 1"
 LinearAlgebra = "1.10"
 LinearSolve = "2.36.2, 3"
-Mooncake = "0.4, 0.5"
+Mooncake = "0.5.36"
 OptimizationIpopt = "1"
 OrdinaryDiffEqRosenbrock = "1, 2"
 PreallocationTools = "1.2"


### PR DESCRIPTION
## Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

This is the "limit to latest Mooncake" fix for the promotion-caused Downgrade `Unsatisfiable` wall. The old Mooncake `[compat]` unions let the Downgrade/DowngradeSublibraries CI pin an ancient Mooncake at minimum resolution; because these sublibs promote Mooncake (a test extra) into the resolved dep set, the resolver could not satisfy the pinned ancient Mooncake. Limiting the floor to the latest registered Mooncake (0.5.36) lets min-resolution succeed.

### Raised floors
| Package | old Mooncake compat | new |
|---|---|---|
| `lib/BoundaryValueDiffEqFIRK` | `0.4.146, 0.5` | `0.5.36` |
| `lib/BoundaryValueDiffEqMIRK` | `0.4, 0.5` | `0.5.36` |

Patch-bumped both sublibraries `1.17.1` → `1.17.2` (a `[compat]` narrowing on a test-only weakdep is a patch-level change).

### Verification (resolves_at_min = true)
Ran `julia-actions/julia-downgrade-compat`'s `downgrade.jl` (`mode=alldeps`, `julia_version=1.12`, effective skip = Julia stdlibs ∪ in-repo `lib/*` names, mirroring `sublibrary-downgrade.yml@v1`) on both edited sublibraries on Julia 1.12.6. Both resolved successfully at minimum versions with **Mooncake pinned to exactly `0.5.36`** — no `Unsatisfiable`. The Resolver-capacity wall does not persist here; the floor-raise alone fixes it (no dependency on #52).

ignore until reviewed by @ChrisRackauckas