### PR TITLE
Silence :unsupported_kwargs by default in the optimize path

### DIFF
--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.1"
+version = "2.7.2"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqCore/src/verbosity.jl
+++ b/lib/BoundaryValueDiffEqCore/src/verbosity.jl
@@ -63,7 +63,11 @@
         ),
         Standard = (
             nonlinear_verbosity = Standard(),
-            optimization_verbosity = Standard(),
+            # BVP forwards common tolerances (e.g. `abstol`) into the inner optimizer as
+            # plumbing; whether a given backend consumes them (Ipopt ignores `abstol`) is
+            # not something the BVP user chose, so the default preset silences the
+            # `:unsupported_kwargs` notice. Higher presets (Detailed/All) still surface it.
+            optimization_verbosity = OptimizationVerbosity(; preset = Standard(), unsupported_kwargs = Silent()),
             bvpsol_convergence = WarnLevel(),
             bvpsol_integrator = WarnLevel(),
             bvpsol_linear_solver = WarnLevel(),


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

Fixes #524.

## Problem

The MIRK Core `@test_nowarn` optimize-path tests (`mirk_basic_tests.jl:628`, `:650`) fail on Julia 1.12. The Ipopt solve **succeeds** (`EXIT: Optimal Solution Found.`); the failure is that OptimizationIpopt v1.2.2+ emits an `@info` at the default verbosity:

```
┌ Info: Verbosity toggle: unsupported_kwargs
└  common abstol is currently not used by IpoptOptimizer(...)
```

`Test.contains_warn` counts that log as output, so `@test_nowarn` fails. BVP forwards its common `abstol` into the inner optimizer, and Ipopt uses `tol` (from `reltol`), not `abstol` — so it reports the kwarg as unused.

## Why this approach

`abstol` **is** part of Optimization.jl's common interface, and the `:unsupported_kwargs` notice is *by design* — at the `Standard`/`Detailed`/`All` presets that toggle is `InfoLevel`, `Silent` only at `None`/`Minimal` (`OptimizationBase/src/verbosity.jl`). So nothing is misbehaving upstream.

Rather than stop forwarding `abstol` (an earlier iteration of this PR) — which would also withhold it from optimizers that *do* consume it — this silences the `:unsupported_kwargs` toggle in BVP's **default** (`Standard`) `optimization_verbosity`. Whether a given backend consumes a forwarded common kwarg is BVP plumbing, not a choice the BVP user made, so the default shouldn't surface it. This is also more general: it covers any ignored common kwarg, not just `abstol`.

Higher presets still surface it for debugging, and users can pass a custom `optimization_verbosity`.

## Verification (local, Julia 1.12.4, exact issue versions: OptimizationIpopt 1.2.2 / OptimizationBase 5.1.4 / Ipopt 1.15.0)

- **Unmodified `master`:** both testsets fail — the `unsupported_kwargs`/`common abstol is currently not used` `@info` fires and `@test_nowarn` reports `Fail`.
- **With this change:** both testsets pass (`1/1` each); no notice at default verbosity; Ipopt still exits `Optimal Solution Found.`
- Behavior check: default (`Standard`) → notice silenced; `All()` → notice still surfaces (escape hatch intact); `abstol` is still forwarded to the optimizer.

Patch-bumps `BoundaryValueDiffEqCore` (2.7.1 → 2.7.2). Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)