### PR TITLE
Fix verbose_tests.jl (Misc + Downgrade lanes): dead @SciMLMessage import and stale Standard-preset optimization_verbosity assertions

### DIFF
--- a/test/misc/verbose_tests.jl
+++ b/test/misc/verbose_tests.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "Verbose field in caches" begin
     using BoundaryValueDiffEq, BoundaryValueDiffEqCore
-    using BoundaryValueDiffEqCore: @SciMLMessage, SciMLLogging
+    using BoundaryValueDiffEqCore: SciMLLogging
 
     # Simple pendulum problem for testing
     tspan = (0.0, pi / 2)
@@ -94,7 +94,7 @@ end
 
 @testset "Verbose field in MIRKN cache" begin
     using BoundaryValueDiffEq, BoundaryValueDiffEqCore
-    using BoundaryValueDiffEqCore: @SciMLMessage, SciMLLogging
+    using BoundaryValueDiffEqCore: SciMLLogging
 
     # Second order BVP for MIRKN
     tspan = (0.0, 1.0)
@@ -130,7 +130,7 @@ end
 
 @testset "Verbose persistence through solve" begin
     using BoundaryValueDiffEq, BoundaryValueDiffEqCore
-    using BoundaryValueDiffEqCore: @SciMLMessage, SciMLLogging
+    using BoundaryValueDiffEqCore: SciMLLogging
 
     # Simple test problem
     tspan = (0.0, 1.0)
@@ -166,6 +166,15 @@ end
 @testset "Internal solver verbosity integration" begin
     using BoundaryValueDiffEq, BoundaryValueDiffEqCore
     using BoundaryValueDiffEqCore: SciMLLogging
+    using OptimizationBase: OptimizationVerbosity
+
+    # The Standard preset silences the optimizer's `:unsupported_kwargs` notice
+    # (BVP forwards common tolerances into the inner optimizer as plumbing), so
+    # `optimization_verbosity` is a customized OptimizationVerbosity, not the bare
+    # `Standard()` preset.
+    standard_opt_verbosity = OptimizationVerbosity(;
+        preset = SciMLLogging.Standard(), unsupported_kwargs = SciMLLogging.Silent()
+    )
 
     # Test BVPVerbosity has both verbosity fields
     @testset "Verbosity fields exist" begin
@@ -173,7 +182,7 @@ end
         @test hasfield(typeof(v), :nonlinear_verbosity)
         @test hasfield(typeof(v), :optimization_verbosity)
         @test v.nonlinear_verbosity == SciMLLogging.Standard()
-        @test v.optimization_verbosity == SciMLLogging.Standard()
+        @test v.optimization_verbosity == standard_opt_verbosity
     end
 
     # Test preset matching for both verbosity controls
@@ -196,7 +205,7 @@ end
         v = BVPVerbosity(SciMLLogging.Standard())
         @test v.bvpsol_convergence == SciMLLogging.WarnLevel()
         @test v.nonlinear_verbosity == SciMLLogging.Standard()
-        @test v.optimization_verbosity == SciMLLogging.Standard()
+        @test v.optimization_verbosity == standard_opt_verbosity
     end
 
     # Test integration with solve - verify it doesn't error


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Problem

The `Misc` test group is red on `master` — on every Julia lane (lts/1/pre) of the normal `CI` run **and** on the `Downgrade` (Misc) lane. The audit filed this under `FLOOR:SciMLLogging` ("downgraded SciMLLogging lacks `@SciMLMessage`"), but the failure is **not** downgrade-specific: it reproduces byte-identically on the latest registered deps (SciMLLogging 2.0.1 + OptimizationBase 5.1.4) as well as at the downgrade floor (SciMLLogging 1.10.1). `test/misc/verbose_tests.jl` has two independent bugs:

1. **`UndefVarError: @SciMLMessage`** (verbose_tests.jl:6, 97, 133).
   `using BoundaryValueDiffEqCore: @SciMLMessage` — but `BoundaryValueDiffEqCore` never imports or exports `@SciMLMessage` (only `BoundaryValueDiffEqShooting` uses it, imported directly from `SciMLLogging`). The macro is **never referenced in any test body**; the import only ever resolved by an accidental transitive re-export leak, which does not hold across dependency versions.

2. **`@test v.optimization_verbosity == SciMLLogging.Standard()`** fails (verbose_tests.jl:176, 199).
   PR #527 deliberately changed the `Standard` preset so `optimization_verbosity = OptimizationVerbosity(; preset = Standard(), unsupported_kwargs = Silent())` — BVP silences the optimizer’s `:unsupported_kwargs` notice because it forwards common tolerances into the inner optimizer as plumbing. That value is intentionally **not** the bare `Standard()` preset, so `== Standard()` is `false`. The test assertions were not updated to match.

## Fix

- Drop the dead `@SciMLMessage` from the three test imports (keep `SciMLLogging`, which is genuinely used).
- Compare `optimization_verbosity` against the actual constructed value, `OptimizationVerbosity(; preset = Standard(), unsupported_kwargs = Silent())`, in the two Standard-preset assertions.

No source changes; the source behavior from #527 is correct — only the tests were stale.

## Verification

Reproduced both failures locally at the exact downgrade floor (SciMLLogging 1.10.1, OptimizationBase 5.1.4, Julia 1.10) and confirmed the fix:

```
BVPVerbosity().optimization_verbosity          == standard_opt_verbosity  -> true
BVPVerbosity(Standard()).optimization_verbosity == standard_opt_verbosity  -> true
BVPVerbosity(None()).optimization_verbosity     == None()                  -> true   (unchanged, still passes)
```

The same equality holds on SciMLLogging 2.0.1 (self-consistent), so this fixes the normal `Misc` lanes and the `Downgrade` (Misc) lane together. Runic: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)