### PR TITLE
Fix MIRK constrained interpolation without controls

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
@@ -9,6 +9,11 @@ function SciMLBase.interp_summary(interp::MIRKInterpolation)
     return "MIRK Order $(interp.cache.order) Interpolation"
 end
 
+__has_control_variables(cache::MIRKCache, length_z) = !isnothing(cache.f_prototype) &&
+    length(cache.f_prototype) < length_z
+__state_variable_count(cache::MIRKCache, length_z) = __has_control_variables(cache, length_z) ?
+    length(cache.f_prototype) : length_z
+
 function (id::MIRKInterpolation)(tvals, idxs, deriv, p, continuity::Symbol = :left)
     return interpolation(tvals, id, idxs, deriv, p, continuity)
 end
@@ -99,10 +104,10 @@ end
     (; s_star) = cache.ITU
     dt = cache.mesh_dt[i]
 
-    has_control = !isnothing(cache.prob.f.f_prototype)
+    has_control = __has_control_variables(cache, length(z))
 
     # state variables have their interpolation polynomials
-    length_z = has_control ? length(cache.prob.f.f_prototype) : length(z)
+    length_z = __state_variable_count(cache, length(z))
     z .= zero(z)
     __maybe_matmul!(z[1:length_z], k_discrete[i].du[1:length_z, 1:stage], w[1:stage])
     __maybe_matmul!(
@@ -128,8 +133,8 @@ end
     (; s_star) = cache.ITU
     dt = cache.mesh_dt[i]
 
-    has_control = !isnothing(cache.prob.f.f_prototype)
-    length_z = has_control ? length(cache.prob.f.f_prototype) : length(z)
+    has_control = __has_control_variables(cache, length(z))
+    length_z = __state_variable_count(cache, length(z))
 
     z .= zero(z)
     __maybe_matmul!(z[1:length_z], k_discrete[i][1:length_z, 1:stage], w[1:stage])
@@ -155,8 +160,8 @@ end
     ) where {iip, T, use_both}
     (; stage, k_discrete, k_interp, M) = cache
     (; s_star) = cache.ITU
-    has_control = !isnothing(cache.prob.f.f_prototype)
-    length_z = has_control ? length(cache.prob.f.f_prototype) : length(z′)
+    has_control = __has_control_variables(cache, length(z′))
+    length_z = __state_variable_count(cache, length(z′))
 
     z′ .= zero(z′)
     __maybe_matmul!(z′[1:length_z], k_discrete[i].du[1:length_z, 1:stage], w′[1:stage])
@@ -167,7 +172,7 @@ end
 
     # control variable just use linear interpolation
     if has_control
-        inc = τ .* id.u[i + 1] .+ (1 - τ) .* id.u[i]
+        inc = (id.u[i + 1] .- id.u[i]) ./ cache.mesh_dt[i]
         copyto!(z′, (length_z + 1):M, inc, (length_z + 1):M)
     end
 
@@ -179,8 +184,8 @@ end
     ) where {iip, T, use_both}
     (; stage, k_discrete, k_interp, M) = cache
     (; s_star) = cache.ITU
-    has_control = !isnothing(cache.prob.f.f_prototype)
-    length_z = has_control ? length(cache.prob.f.f_prototype) : length(z′)
+    has_control = __has_control_variables(cache, length(z′))
+    length_z = __state_variable_count(cache, length(z′))
 
     z′ .= zero(z′)
     __maybe_matmul!(z′[1:length_z], k_discrete[i][1:length_z, 1:stage], w′[1:stage])
@@ -191,7 +196,7 @@ end
 
     # control variable just use linear interpolation
     if has_control
-        inc = τ .* id.u[i + 1] .+ (1 - τ) .* id.u[i]
+        inc = (id.u[i + 1] .- id.u[i]) ./ cache.mesh_dt[i]
         copyto!(z′, (length_z + 1):M, inc, (length_z + 1):M)
     end
 
@@ -213,9 +218,8 @@ function (s::EvalSol{C})(tval::Number) where {C <: MIRKCache}
     (tval == t[1]) && return first(u)
     (tval == t[end]) && return last(u)
     z = zero(last(u))
-    f_prototype = cache.prob.f.f_prototype
-    has_control = !isnothing(f_prototype)
-    length_z = has_control ? length(f_prototype) : length(z)
+    has_control = __has_control_variables(cache, length(z))
+    length_z = __state_variable_count(cache, length(z))
     ii = interval(t, tval)
     dt = cache.mesh_dt[ii]
     τ = (tval - t[ii]) / dt
@@ -243,9 +247,8 @@ function (s::EvalSol{C})(tvals::AbstractArray{<:Number}) where {C <: MIRKCache}
     (; alg, stage, k_discrete, k_interp, mesh_dt, M) = cache
     # Quick handle for the case where tval is at the boundary
     zvals = [zero(last(u)) for _ in tvals]
-    f_prototype = cache.prob.f.f_prototype
-    has_control = !isnothing(f_prototype)
-    length_z = has_control ? length(f_prototype) : length(first(zvals))
+    has_control = __has_control_variables(cache, length(first(zvals)))
+    length_z = __state_variable_count(cache, length(first(zvals)))
     for (i, tval) in enumerate(tvals)
         (tval == t[1]) && return first(u)
         (tval == t[end]) && return last(u)

--- a/lib/BoundaryValueDiffEqMIRK/test/Core/dynamic_optimization_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/Core/dynamic_optimization_tests.jl
@@ -64,3 +64,26 @@ using Test
     sol = solve(rocket_launch_prob_tp, MIRK4(; optimize = IpoptOptimizer()); dt = Δt, adaptive = false)
     @test SciMLBase.successful_retcode(sol)
 end
+
+@testset "Constrained interpolation without control variables" begin
+    using OptimizationIpopt
+
+    function constrained_f!(du, u, p, t)
+        du[1] = u[2]
+        du[2] = u[1]
+    end
+
+    function constrained_bc!(res, u, p, t)
+        res[1] = u(0.0)[1] - 1
+        res[2] = u(1.0)[1]
+    end
+
+    constrained_fun = BVPFunction(constrained_f!, constrained_bc!; f_prototype = zeros(2))
+    constrained_prob = BVProblem(
+        constrained_fun, [0.0, 0.0], (0.0, 1.0); lb = [-10.0, -10.0], ub = [10.0, 10.0]
+    )
+    sol = solve(constrained_prob, MIRK4(; optimize = IpoptOptimizer()); dt = 0.01)
+
+    @test SciMLBase.successful_retcode(sol)
+    @test sol(0.5) ≈ [sinh(0.5) / sinh(1.0), -cosh(0.5) / sinh(1.0)] rtol = 1.0e-4
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Distinguish true control-variable BVPs from constrained pure-state BVPs in MIRK interpolation.
- Keep linear interpolation only for solution entries beyond `f_prototype`, instead of treating every non-`nothing` `f_prototype` as controls.
- Add a regression test for the issue #533 constrained MIRK4 + Ipopt interpolation case with no cost function.

## Verification

- Reproduced issue #533 locally on current `master`: solve returned `Success`, then `sol(0.5)` threw `ArgumentError: range must be non-empty` from `BoundaryValueDiffEqMIRK/src/interpolation.jl:116`.
- Ran the patched MRE in a temporary Julia environment developing this checkout: solve returned `Success`; `sol(0.5) = [0.4434094419864602, -0.9595173756818917]`.
- Ran Runic.jl formatting on the two touched files via a temporary local environment.
- Ran `git diff --check`: passed.
- Ran `timeout 3600 julia --project=lib/BoundaryValueDiffEqMIRK -e 'using Pkg; Pkg.test()'`: failed/timed out after one hour. Before timeout, existing MIRK basic tests reported `MethodError: no method matching Float64(::ForwardDiff.Dual...)` in `Swirling Flow III`, `Test interpolant evaluation with big defect`, and `Test maxsol and minsol`; then the suite continued through many Ipopt solves until timeout. A separate agent is investigating whether that reproduces on clean `master`.
