### PR TITLE
Allow constrained MIRK without f_prototype

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
@@ -84,7 +84,11 @@ function SciMLBase.__init(
     y = __alloc.(copy.(y₀.u))
     TU, ITU = constructMIRK(alg, T)
     stage = alg_stage(alg)
-    f_prototype = isnothing(prob.f.f_prototype) ? nothing : __vec(prob.f.f_prototype)
+    f_prototype = if isnothing(prob.f.f_prototype)
+        constraint ? __vec(u0) : nothing
+    else
+        __vec(prob.f.f_prototype)
+    end
     L_f_prototype = isnothing(f_prototype) ? N : length(f_prototype)
 
     k_discrete = if !constraint

--- a/lib/BoundaryValueDiffEqMIRK/test/Core/dynamic_optimization_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/Core/dynamic_optimization_tests.jl
@@ -78,12 +78,16 @@ end
         res[2] = u(1.0)[1]
     end
 
-    constrained_fun = BVPFunction(constrained_f!, constrained_bc!; f_prototype = zeros(2))
-    constrained_prob = BVProblem(
-        constrained_fun, [0.0, 0.0], (0.0, 1.0); lb = [-10.0, -10.0], ub = [10.0, 10.0]
-    )
-    sol = solve(constrained_prob, MIRK4(; optimize = IpoptOptimizer()); dt = 0.01)
+    for constrained_fun in (
+            BVPFunction(constrained_f!, constrained_bc!),
+            BVPFunction(constrained_f!, constrained_bc!; f_prototype = zeros(2)),
+        )
+        constrained_prob = BVProblem(
+            constrained_fun, [0.0, 0.0], (0.0, 1.0); lb = [-10.0, -10.0], ub = [10.0, 10.0]
+        )
+        sol = solve(constrained_prob, MIRK4(; optimize = IpoptOptimizer()); dt = 0.01)
 
-    @test SciMLBase.successful_retcode(sol)
-    @test sol(0.5) ≈ [sinh(0.5) / sinh(1.0), -cosh(0.5) / sinh(1.0)] rtol = 1.0e-4
+        @test SciMLBase.successful_retcode(sol)
+        @test sol(0.5) ≈ [sinh(0.5) / sinh(1.0), -cosh(0.5) / sinh(1.0)] rtol = 1.0e-4
+    end
 end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- For constrained MIRK solves, fall back to the vectorized extracted `u0` when no `f_prototype` is supplied.
- Keep unconstrained MIRK behavior unchanged by leaving `f_prototype` as `nothing` when there are no constraints.
- Extend the constrained interpolation regression to exercise both omitted `f_prototype` and explicit full-state `f_prototype`.

## Motivation

The constrained BVP case from https://discourse.julialang.org/t/interpolating-solution-to-constrained-bvp/137989/4 should not require `f_prototype` when the residual has the same size as `u0`.

## Validation

- Ran `Runic` check across the repository: passed.
- Ran direct dynamic optimization regression in a local test environment developing `BoundaryValueDiffEqCore` and `BoundaryValueDiffEqMIRK`: `include("lib/BoundaryValueDiffEqMIRK/test/Core/dynamic_optimization_tests.jl")`; rocket launching passed 2/2 and constrained interpolation passed 4/4.
- Attempted `BOUNDARYVALUEDIFFEQ_TEST_GROUP=Core Pkg.test()` for `BoundaryValueDiffEqMIRK`; it hit an unrelated existing `Swirling Flow III` failure in `mirk_basic_tests.jl:311` (`MethodError: no method matching Float64(::ForwardDiff.Dual...)`). The stacktrace shows `cache.f_prototype` is `Nothing`, i.e. the unconstrained path this PR intentionally leaves unchanged.
