### PR TITLE
Fix MultipleShooting caches for tagged AD states

### DIFF
--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.3"
+version = "1.17.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/src/multiple_shooting.jl
+++ b/lib/BoundaryValueDiffEqShooting/src/multiple_shooting.jl
@@ -45,6 +45,7 @@ function SciMLBase.__solve(
 
     internal_ode_kwargs = (; kwargs..., odesolve_kwargs..., save_end = true)
 
+    odecache_by_eltype = Dict{Tuple{Any, Int}, Any}()
     solve_internal_odes! = @closure (
         resid_nodes,
         us,
@@ -52,9 +53,15 @@ function SciMLBase.__solve(
         cur_nshoot,
         nodes,
         odecache,
-    ) -> __multiple_shooting_solve_internal_odes!(
-        resid_nodes, us, cur_nshoot, odecache, nodes, u0_size, N, ensemblealg, tspan
-    )
+    ) -> begin
+        odecache_ = __multiple_shooting_odecache_for_eltype(
+            odecache, odecache_by_eltype, ensemblealg, prob, alg.ode_alg, us, cur_nshoot,
+            u0_size, N, internal_ode_kwargs
+        )
+        __multiple_shooting_solve_internal_odes!(
+            resid_nodes, us, cur_nshoot, odecache_, nodes, u0_size, N, ensemblealg, tspan
+        )
+    end
 
     # This gets all the nshoots except the final SingleShooting case
     all_nshoots = __get_all_nshoots(alg.grid_coarsening, nshoots)
@@ -360,6 +367,21 @@ function __multiple_shooting_init_jacobian_odecache(
     return __multiple_shooting_init_odecache(
         ensemblealg, prob, alg, xduals, nshoots; kwargs...
     )
+end
+
+function __multiple_shooting_odecache_for_eltype(
+        odecache, odecache_by_eltype, ensemblealg, prob, ode_alg, us, nshoots, u0_size, N,
+        internal_ode_kwargs
+    )
+    cache = odecache isa Vector ? first(odecache) : odecache
+    eltype(cache.u) === eltype(us) && return odecache
+
+    return get!(odecache_by_eltype, (eltype(us), nshoots)) do
+        u0 = copy(reshape(@view(us[1:N]), u0_size))
+        __multiple_shooting_init_odecache(
+            ensemblealg, prob, ode_alg, u0, nshoots; internal_ode_kwargs...
+        )
+    end
 end
 
 # Not using `EnsembleProblem` since it is hard to initialize the cache and stuff

--- a/lib/BoundaryValueDiffEqShooting/test/Core/basic_problems_tests.jl
+++ b/lib/BoundaryValueDiffEqShooting/test/Core/basic_problems_tests.jl
@@ -72,6 +72,14 @@ using Test
         @test norm(sol.resid, Inf) < 1.0e-8
     end
 
+    serial_sol = solve(
+        bvp2, MultipleShooting(10, Tsit5()); abstol = 1.0e-8, reltol = 1.0e-8,
+        odesolve_kwargs = (; abstol = 1.0e-6, reltol = 1.0e-3), maxiters = 10000,
+        ensemblealg = EnsembleSerial()
+    )
+    @test SciMLBase.successful_retcode(serial_sol)
+    @test norm(serial_sol.resid, Inf) < 1.0e-8
+
     # Inplace
     bc2a!(resid, ua, p) = (resid[1] = ua[1])
     bc2b!(resid, ub, p) = (resid[1] = ub[1] - 1)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- lazily initialize and reuse MultipleShooting ODE integrator caches for each nonlinear-state element type and shooting-grid size
- keep the BVP time type unchanged when ForwardDiff introduces tagged state values
- cover the previously untested serial execution path and bump BoundaryValueDiffEqShooting to 1.17.4

## Cause

MultipleShooting hoists ODE integrator allocation out of residual evaluations. The default nonlinear polyalgorithm can evaluate that residual with a new tagged `ForwardDiff.Dual` element type when it falls back to its line-search method. Reinitializing the original `Float64` ODE cache with those states throws `Float64(::ForwardDiff.Dual)`.

The existing DifferentiationInterface Jacobian caches continue using their preallocated matching ODE caches. The new fallback is only used when another caller introduces a different state element type, and it reuses the resulting cache after the first evaluation.

This is separate from #571, which only adjusts the LinearSolve test compatibility range.

## Verification

- Exact downgrade reproducer before the fix:
  - `EnsembleThreads`: `Float64(::ForwardDiff.Dual{ForwardDiff.Tag{NonlinearFunction...}})`
  - `EnsembleSerial`: the same conversion error
- Exact downgrade after the fix, Julia 1.10.11:
  - `BOUNDARYVALUEDIFFEQ_TEST_GROUP=Core`: Basic 84/84, NLLS 56/56, Orbital 40/40
- Latest compatible dependencies, Julia 1.12.6:
  - `BOUNDARYVALUEDIFFEQ_TEST_GROUP=All`: Basic 84/84, NLLS 56/56, Orbital 40/40
  - `BOUNDARYVALUEDIFFEQ_TEST_GROUP=QA`: 19/19
- The earlier implementation's benchmark run found unchanged allocation counts and statistically neutral MultipleShooting timings; this narrower implementation will be rechecked by fresh CI.
- whole-repository Runic check: passed