### PR TITLE
Anchor public docs QA paths to repo root

### DIFF
--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -7,14 +7,15 @@ using BoundaryValueDiffEqMIRKN
 using BoundaryValueDiffEqShooting
 using Test
 
+const REPOSITORY_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
 const PUBLIC_API_SOURCE_DIRS = Dict(
-    BoundaryValueDiffEq => ["src"],
-    BoundaryValueDiffEqAscher => ["lib/BoundaryValueDiffEqAscher/src"],
-    BoundaryValueDiffEqCore => ["lib/BoundaryValueDiffEqCore/src"],
-    BoundaryValueDiffEqFIRK => ["lib/BoundaryValueDiffEqFIRK/src"],
-    BoundaryValueDiffEqMIRK => ["lib/BoundaryValueDiffEqMIRK/src"],
-    BoundaryValueDiffEqMIRKN => ["lib/BoundaryValueDiffEqMIRKN/src"],
-    BoundaryValueDiffEqShooting => ["lib/BoundaryValueDiffEqShooting/src"],
+    BoundaryValueDiffEq => [joinpath(REPOSITORY_ROOT, "src")],
+    BoundaryValueDiffEqAscher => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqAscher", "src")],
+    BoundaryValueDiffEqCore => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqCore", "src")],
+    BoundaryValueDiffEqFIRK => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqFIRK", "src")],
+    BoundaryValueDiffEqMIRK => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqMIRK", "src")],
+    BoundaryValueDiffEqMIRKN => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqMIRKN", "src")],
+    BoundaryValueDiffEqShooting => [joinpath(REPOSITORY_ROOT, "lib", "BoundaryValueDiffEqShooting", "src")],
 )
 
 function strip_comment(line)
@@ -93,7 +94,7 @@ end
 
 function docs_entries()
     entries = Set{String}()
-    docs_dir = joinpath("docs", "src")
+    docs_dir = joinpath(REPOSITORY_ROOT, "docs", "src")
     for (dir, _, files) in walkdir(docs_dir)
         for file in files
             endswith(file, ".md") || continue


### PR DESCRIPTION
## Summary

Fixes the public API docs coverage QA test so it resolves source and docs paths from the repository root instead of the active QA working directory.

Root cause: PR #538 added `test/qa/public_api_docs.jl`, but `docs_entries()` used relative `docs/src`. In the QA group, SciMLTesting activates `test/qa`, so the relative path resolves from the wrong directory and CI errors with `readdir("docs/src")`.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Validation

- Reproduced on clean `master` at `fcc08ec5ed78c09662df5d90975fbacbf481b89c`: `GROUP=QA /home/crackauc/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.activate("."); Pkg.test(; coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], allow_reresolve=true)'` errored in `test/qa/public_api_docs.jl` with `IOError: readdir("docs/src")`.
- Verified parent `fa36d42aecd067155e80a63a9aa8174565c1f396` passes the same QA command with `Quality Assurance | 17 / 17`.
- Verified this branch passes the same QA command with `Quality Assurance | 173 / 173`.
- Ran Runic check: `/home/crackauc/.juliaup/bin/julia +1 --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/.runic_env -m Runic --check .`.