### PR TITLE
Avoid FIRK collocation views in AD residuals

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/src/firk.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/firk.jl
@@ -1411,7 +1411,7 @@ end
         cache, eval_sol, trait::NoDiffCacheNeeded, constraint
     ) where {BC}
     y_ = recursive_unflatten!(y, u)
-    resids = [r for r in residual]
+    resids = residual
     Φ!(resids[2:end], cache, y_, u, trait, constraint)
     eval_sol.u[1:end] .= y_
     eval_bc_residual!(resids[1], pt, bc!, eval_sol, p, mesh)
@@ -1508,23 +1508,49 @@ end
     return eval_bc_residual(pt, bc!, eval_sol, p, mesh)
 end
 
+function __firk_recursive_unflatten!(y::Vector{<:AbstractArray}, x::AbstractVector)
+    i = firstindex(x)
+    for yᵢ in y
+        for j in eachindex(yᵢ)
+            yᵢ[j] = x[i]
+            i += 1
+        end
+    end
+    return y
+end
+
+function __firk_recursive_unflatten!(y::Vector{<:DiffCache}, x::AbstractVector)
+    return __firk_recursive_unflatten!(get_tmp.(y, (x,)), x)
+end
+
+function __firk_recursive_flatten!(y::AbstractVector, x)
+    i = firstindex(y)
+    for xᵢ in x
+        for j in eachindex(xᵢ)
+            y[i] = xᵢ[j]
+            i += 1
+        end
+    end
+    return y
+end
+
 @views function __firk_loss_collocation!(
         resid, u, p, y, mesh, residual, cache, trait::DiffCacheNeeded, constraint
     )
-    y_ = recursive_unflatten!(y, u)
+    y_ = __firk_recursive_unflatten!(y, u)
     resids = [get_tmp(r, u) for r in residual[2:end]]
     Φ!(resids, cache, y_, u, trait, constraint)
-    recursive_flatten!(resid, resids)
+    __firk_recursive_flatten!(resid, resids)
     return nothing
 end
 
 @views function __firk_loss_collocation!(
         resid, u, p, y, mesh, residual, cache, trait::NoDiffCacheNeeded, constraint
     )
-    y_ = recursive_unflatten!(y, u)
-    resids = [r for r in residual[2:end]]
+    y_ = __firk_recursive_unflatten!(y, u)
+    resids = residual[2:end]
     Φ!(resids, cache, y_, u, trait, constraint)
-    recursive_flatten!(resid, resids)
+    __firk_recursive_flatten!(resid, resids)
     return nothing
 end
 


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add FIRK-local scalar flatten/unflatten helpers for the collocation residual Jacobian path.
- Use those helpers in `__firk_loss_collocation!` so Enzyme does not trace through `view`/`copyto!`/temporary vector collection while differentiating FIRK collocation residuals.
- Reuse the no-diff-cache residual buffers directly instead of collecting shallow copies.

## Master Reproduction
- Clean `master` at `fcc08ec5ed78c09662df5d90975fbacbf481b89c` reproduced the FIRK AD failure locally with:
  `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_121627_10236/julia_depot_firk_ad_local julia +1 --startup-file=no --project=lib/BoundaryValueDiffEqFIRK/test/AD -e 'import Pkg; Pkg.instantiate(); include("lib/BoundaryValueDiffEqFIRK/test/AD/ad_tests.jl")'`\n- Result on master: `signal 11 (1): Segmentation fault` in `__firk_loss_collocation!` while Enzyme differentiated the collocation Jacobian.\n\n## Validation\n- Labeled first AD testset on this branch: ForwardDiff, Enzyme, and Mooncake-boundary/Enzyme-collocation cases all returned `SciMLBase.successful_retcode(sol) = true`.\n- Direct AD include on this branch: `Different AD compatibility | 9 / 9` in 17m51.1s.\n- CI-shaped FIRK AD group on this branch:\n  `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_121627_10236/julia_depot_firk_ad_view_patch BOUNDARYVALUEDIFFEQ_TEST_GROUP=AD julia +1 --startup-file=no --project=lib/BoundaryValueDiffEqFIRK -e 'import Pkg; Pkg.test()'`\n  passed with `FIRK Expanded AD Tests | 9 / 9` and `Testing BoundaryValueDiffEqFIRK tests passed`.\n- Runic check: `julia +1 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/.runic_env -m Runic --check lib/BoundaryValueDiffEqFIRK/src/firk.jl`\n- Spell check: `/home/crackauc/.local/bin/typos lib/BoundaryValueDiffEqFIRK/src/firk.jl`\n- `git diff --check`