### PR TITLE
Avoid dual nested FIRK stage solves

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
@@ -195,7 +195,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = nodual_value(nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ
@@ -227,7 +227,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = nodual_value(nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ

--- a/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
@@ -12,6 +12,11 @@ function Φ!(residual, cache::FIRKCacheNested, y, u, trait, constraint)
     )
 end
 
+@inline function __nested_stage_parameter(cache::FIRKCacheNested, p)
+    length(cache.bcresid_prototype) < cache.M && return nodual_value(p)
+    return p
+end
+
 @views function Φ!(
         residual, fᵢ_cache, k_discrete, f!, TU::FIRKTableau{false}, y, u, p,
         mesh, mesh_dt, stage::Int, f_prototype, singular_term, ::DiffCacheNeeded, ::Val{true}
@@ -195,7 +200,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nodual_value(nestprob_p))
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ
@@ -227,7 +232,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nodual_value(nestprob_p))
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ
@@ -385,7 +390,7 @@ end
         nestprob_p[2] = T(mesh_dt[i])
         nestprob_p[3:end] = yᵢ
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
 
         @. residᵢ = yᵢ₊₁ - yᵢ

--- a/lib/BoundaryValueDiffEqFIRK/src/firk.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/firk.jl
@@ -1393,6 +1393,15 @@ function __construct_problem(
     )
 end
 
+@inline function __firk_eval_sol!(eval_sol::EvalSol, y_, cache)
+    u = __restructure_sol(y_, cache.in_size)
+    if eltype(first(u)) <: eltype(first(eval_sol.u))
+        eval_sol.u[1:end] .= u
+        return eval_sol
+    end
+    return EvalSol(u, eval_sol.t, cache)
+end
+
 @views function __firk_loss!(
         resid, u, p, y, pt::StandardBVProblem, bc!::BC, residual, mesh,
         cache, eval_sol, trait::DiffCacheNeeded, constraint
@@ -1400,8 +1409,7 @@ end
     y_ = recursive_unflatten!(y, u)
     resids = [get_tmp(r, u) for r in residual]
     Φ!(resids[2:end], cache, y_, u, trait, constraint)
-    eval_sol.u[1:end] .= y_
-    eval_bc_residual!(resids[1], pt, bc!, eval_sol, p, mesh)
+    eval_bc_residual!(resids[1], pt, bc!, __firk_eval_sol!(eval_sol, y_, cache), p, mesh)
     recursive_flatten!(resid, resids)
     return nothing
 end
@@ -1413,8 +1421,7 @@ end
     y_ = recursive_unflatten!(y, u)
     resids = [r for r in residual]
     Φ!(resids[2:end], cache, y_, u, trait, constraint)
-    eval_sol.u[1:end] .= y_
-    eval_bc_residual!(resids[1], pt, bc!, eval_sol, p, mesh)
+    eval_bc_residual!(resids[1], pt, bc!, __firk_eval_sol!(eval_sol, y_, cache), p, mesh)
     recursive_flatten!(resid, resids)
     return nothing
 end
@@ -1473,8 +1480,7 @@ end
         u, p, y, pt::StandardBVProblem, bc::BC, mesh, cache, eval_sol, trait
     ) where {BC}
     y_ = recursive_unflatten!(y, u)
-    eval_sol.u[1:end] .= y_
-    resid_bc = eval_bc_residual(pt, bc, eval_sol, p, mesh)
+    resid_bc = eval_bc_residual(pt, bc, __firk_eval_sol!(eval_sol, y_, cache), p, mesh)
     resid_co = Φ(cache, y_, u, trait)
     return vcat(resid_bc, mapreduce(vec, vcat, resid_co))
 end

--- a/lib/BoundaryValueDiffEqFIRK/src/firk.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/firk.jl
@@ -1528,7 +1528,10 @@ end
         resid, u, p, y, mesh, residual, cache, trait::NoDiffCacheNeeded, constraint
     )
     y_ = recursive_unflatten!(y, u)
-    resids = [r for r in residual[2:end]]
+    resids = Vector{eltype(residual)}(undef, length(residual) - 1)
+    for i in eachindex(resids)
+        resids[i] = residual[i + 1]
+    end
     Φ!(resids, cache, y_, u, trait, constraint)
     recursive_flatten!(resid, resids)
     return nothing


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Avoid differentiating through singular underconstrained nested FIRK stage solves during outer collocation Jacobian evaluation.
- Preserve dual parameters for square nested stage systems so standard initial-guess and VectorOfArray paths keep their expected Jacobian behavior.
- Avoid mutating a Float64-backed `EvalSol.u` with ForwardDiff dual state vectors; allocate a dual-compatible `EvalSol` only when needed.
- Avoid an Enzyme/GC-sensitive AD crash in the FIRK collocation loss by copying residual slots explicitly instead of collecting `residual[2:end]`.
- The temporary test selector used for local reproduction is not committed.

## Clean-master reproduction

Clean checkout of SciML/BoundaryValueDiffEq.jl at `906ff8948661c8a917111db3e3e5a4e7b1185ae0` reproduced the LobattoIIIa failures and the LobattoIIIb Newton hang under the FIRK `Pkg.test()` resolver. A plain package-environment script did not reproduce the LobattoIIIa singularity; the failing state is tied to the FIRK test resolver and nested solve AD path.

Resolver state from the failing clean-master FIRK test env included:

- `LinearSolve v3.87.0`
- `SciMLBase v3.35.1`
- `NonlinearSolveBase v2.33.0`
- `NonlinearSolveFirstOrder v2.1.3`
- `ForwardDiff v1.4.1`
- `OrdinaryDiffEqRosenbrock v2.4.0`

Problem 1 command:

```bash
set -o pipefail
export JULIA_DEPOT_PATH="$PWD/../julia_depot_nested_nlls_pkgtest_master_20260711:"
timeout 3600 env \
  BOUNDARYVALUEDIFFEQ_TEST_GROUP=NESTED_NLLS_SELECTOR \
  BOUNDARYVALUEDIFFEQ_FIRK_NLLS_PART=UNDERCONSTRAINED_LOBATTOA_PROBLEM1 \
  /usr/bin/time -p /home/crackauc/.juliaup/bin/julia +1 --startup-file=no \
  --project=lib/BoundaryValueDiffEqFIRK -e 'using Pkg; Pkg.test()' \
  2>&1 | tee ../nested_nlls_lobattoa_problem1_pkgtest_master_906ff894.log
```

Result:

```text
FIRK Nested NLLS Selector Tests | 1 pass, 2 errors, total 3, 18m38.5s
LobattoIIIa4 with NewtonRaphson: LinearAlgebra.SingularException(72)
LobattoIIIa4 with GaussNewton: LinearAlgebra.SingularException(72)
LobattoIIIa4 with TrustRegion: pass
real 1434.43
```

Problem 2 command:

```bash
set -o pipefail
export JULIA_DEPOT_PATH="$PWD/../julia_depot_nested_nlls_pkgtest_master_20260711:"
timeout 3600 env \
  BOUNDARYVALUEDIFFEQ_TEST_GROUP=NESTED_NLLS_SELECTOR \
  BOUNDARYVALUEDIFFEQ_FIRK_NLLS_PART=UNDERCONSTRAINED_LOBATTOA_PROBLEM2 \
  /usr/bin/time -p /home/crackauc/.juliaup/bin/julia +1 --startup-file=no \
  --project=lib/BoundaryValueDiffEqFIRK -e 'using Pkg; Pkg.test()' \
  2>&1 | tee ../nested_nlls_lobattoa_problem2_pkgtest_master_906ff894.log
```

Result:

```text
FIRK Nested NLLS Selector Tests | 1 pass, 2 errors, total 3, 3m31.2s
LobattoIIIa4 with NewtonRaphson: LinearAlgebra.SingularException(72)
LobattoIIIa4 with GaussNewton: LinearAlgebra.SingularException(72)
LobattoIIIa4 with TrustRegion: pass
```

LobattoIIIb Problem 1 Newton command:

```bash
set -o pipefail
export JULIA_DEPOT_PATH="$PWD/../julia_depot_nested_nlls_pkgtest_master_20260711:"
timeout 3600 env \
  BOUNDARYVALUEDIFFEQ_TEST_GROUP=NESTED_NLLS_SELECTOR \
  BOUNDARYVALUEDIFFEQ_FIRK_NLLS_PART=UNDERCONSTRAINED_LOBATTOB_PROBLEM1_NEWTON \
  /usr/bin/time -p /home/crackauc/.juliaup/bin/julia +1 --startup-file=no \
  --project=lib/BoundaryValueDiffEqFIRK -e 'using Pkg; Pkg.test()' \
  2>&1 | tee ../nested_nlls_lobattob_problem1_newton_pkgtest_master_906ff894.log
```

Result:

```text
timeout exit 124 after 3600s; no test summary
```

The SIGTERM stack for the timeout was in `FIRK_nlsolve!` / `nonlinearsolve_forwarddiff_solve` / `BoundaryValueDiffEqFIRK.__firk_loss!`.

Bisect note: this is not meaningful as a BoundaryValueDiffEq repo-commit regression. It reproduces on clean `master` at the current resolver state, and widening FIRK compat to allow `LinearSolve v4.2.1` alone did not fix Problem 1. The observed culprit is the current dependency-resolution state exposing AD-through-inner-stage-solve behavior for an underconstrained nested stage system.

## Fix

The nested FIRK `DiffCacheNeeded` paths now strip duals only for underconstrained nested stage problems:

```julia
@inline function __nested_stage_parameter(cache::FIRKCacheNested, p)
    length(cache.bcresid_prototype) < cache.M && return nodual_value(p)
    return p
end
```

That avoids NonlinearSolve's implicit ForwardDiff-through-solve path for the singular underconstrained inner stage system while preserving dual propagation for square nested stage systems.

The standard FIRK loss path now builds a dual-compatible `EvalSol` when needed instead of writing dual state vectors into a Float64-backed initial-guess solution cache.

The NoDiffCacheNeeded collocation loss now copies `residual[2:end]` into a fresh vector with an explicit loop. This is behavior-equivalent to the previous comprehension, but avoids a repeatable Enzyme segfault seen only through the `Pkg.test`/SafeTestsets AD harness on this branch.

## Local verification

Final branch state (`ce207c287b164c744e325c31cf9ac6e2e03bdf75`) with the original FIRK test resolver:

```text
UNDERCONSTRAINED_LOBATTOA_PROBLEM1:
FIRK Nested NLLS Selector Tests | 3 pass, total 3, 2m06.2s
real 523.84

UNDERCONSTRAINED_LOBATTOA_PROBLEM2:
FIRK Nested NLLS Selector Tests | 3 pass, total 3, 2m52.2s
real 203.48

UNDERCONSTRAINED_LOBATTOB_PROBLEM1_NEWTON:
FIRK Nested NLLS Selector Tests | 1 pass, total 1, 1m29.7s
real 119.17
```

FIRK AD package test was run twice after the AD-stabilization change:

```bash
timeout 3600 env BOUNDARYVALUEDIFFEQ_TEST_GROUP=AD \
  /usr/bin/time -p /home/crackauc/.juliaup/bin/julia +1 --startup-file=no \
  --project=lib/BoundaryValueDiffEqFIRK \
  -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

Results:

```text
FIRK Expanded AD Tests | 9 pass, total 9, 23m17.4s
Testing BoundaryValueDiffEqFIRK tests passed
real 1744.65

FIRK Expanded AD Tests | 9 pass, total 9, 25m13.5s
Testing BoundaryValueDiffEqFIRK tests passed
real 2114.98
```

Root package Misc group:

```bash
timeout 3600 env BOUNDARYVALUEDIFFEQ_TEST_GROUP=Misc \
  /usr/bin/time -p /home/crackauc/.juliaup/bin/julia +1 --startup-file=no \
  --project=. -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

Result:

```text
Testing BoundaryValueDiffEq tests passed
real 2391.73
```

Formatting/checks:

```text
julia +1 --startup-file=no --project=../.runic_env -m Runic --check lib/BoundaryValueDiffEqFIRK/src/collocation.jl lib/BoundaryValueDiffEqFIRK/src/firk.jl
passed

git diff --check
passed
```

## CI notes

On the previous pushed commit, all FIRK NESTED CI lanes passed. The AD Julia 1 lane reproduced the local branch-specific Enzyme segfault, which is addressed by the final commit here. Current CI for `ce207c28` is pending.

Known unrelated CI observed on the previous run:

- Downgrade Sublibraries FIRK/MIRK resolver conflict: #553
- FIRK AD Julia prerelease Enzyme/BLAS derivative failure: #554
- FIRK EXPANDED lanes reported self-hosted runner lost communication, not test assertion output.