### PR TITLE
Fix QA public API docs paths

### DIFF
--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -7,14 +7,16 @@ using BoundaryValueDiffEqMIRKN
 using BoundaryValueDiffEqShooting
 using Test
 
+const REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+
 const PUBLIC_API_SOURCE_DIRS = Dict(
-    BoundaryValueDiffEq => ["src"],
-    BoundaryValueDiffEqAscher => ["lib/BoundaryValueDiffEqAscher/src"],
-    BoundaryValueDiffEqCore => ["lib/BoundaryValueDiffEqCore/src"],
-    BoundaryValueDiffEqFIRK => ["lib/BoundaryValueDiffEqFIRK/src"],
-    BoundaryValueDiffEqMIRK => ["lib/BoundaryValueDiffEqMIRK/src"],
-    BoundaryValueDiffEqMIRKN => ["lib/BoundaryValueDiffEqMIRKN/src"],
-    BoundaryValueDiffEqShooting => ["lib/BoundaryValueDiffEqShooting/src"],
+    BoundaryValueDiffEq => [joinpath(REPO_ROOT, "src")],
+    BoundaryValueDiffEqAscher => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqAscher", "src")],
+    BoundaryValueDiffEqCore => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqCore", "src")],
+    BoundaryValueDiffEqFIRK => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqFIRK", "src")],
+    BoundaryValueDiffEqMIRK => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqMIRK", "src")],
+    BoundaryValueDiffEqMIRKN => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqMIRKN", "src")],
+    BoundaryValueDiffEqShooting => [joinpath(REPO_ROOT, "lib", "BoundaryValueDiffEqShooting", "src")],
 )
 
 function strip_comment(line)
@@ -93,7 +95,7 @@ end
 
 function docs_entries()
     entries = Set{String}()
-    docs_dir = joinpath("docs", "src")
+    docs_dir = joinpath(REPO_ROOT, "docs", "src")
     for (dir, _, files) in walkdir(docs_dir)
         for file in files
             endswith(file, ".md") || continue


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Anchor the public API docs QA source paths to the repository root.
- Anchor docs entry discovery to the repository root instead of the QA test process working directory.

## Root Cause
The QA group runs from the `test/qa` environment, so relative paths like `src` and `docs/src` can resolve under `test/qa` instead of the repository root. That makes the public API docs coverage check fail in CI.

## Verification
- `timeout 3600 env TMPDIR=/home/crackauc/sandbox/tmp_20260708_121627_10236/tmp JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_121627_10236/julia_depot_bvd_qa_current GROUP=QA julia +1 --startup-file=no --project=. -e 'import Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'`\n  - `Quality Assurance | 173 pass`\n  - `Testing BoundaryValueDiffEq tests passed`\n- `git diff --check origin/master..HEAD`\n- `timeout 3600 julia +1 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/runic_env -e 'using Runic; exit(Runic.main(["--check", "--verbose", "."]))'`\n\n## Notes\n- This only addresses the root CI QA path failure. MIRK/Shooting downgrade, docs, ModelingToolkit downstream, and FIRK EXPANDED failures are separate master failures.