### PR TITLE
Release prep: batched version bumps for 7 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.22.1"
+version = "5.23.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.1"
+version = "1.15.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.2"
+version = "2.7.3"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.1"
+version = "1.17.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.1"
+version = "1.17.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.16.1"
+version = "1.16.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.2"
+version = "1.17.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

Batched patch-release version bumps for every package in this monorepo that has unreleased, release-appropriate changes on `master`. No `[compat]` floor edits were needed (see cascade analysis below) — this PR only touches `version` fields.

| Package | Old | New | Reason |
|---|---|---|---|
| BoundaryValueDiffEq (root) | 5.22.1 | **5.23.1** | Forced target version. Root's `Project.toml` was manually downgraded below the already-registered 5.23.0 by a deliberate one-off commit on 2026-04-27 (unrelated to normal development). Everything on `master` since the 5.23.0 registration commit is mechanical: ExplicitImports refactor (`using X` → explicit import lists, same symbols via existing re-exports, no new public API), CI/QA scaffolding, docs. Patch-appropriate. |
| BoundaryValueDiffEqAscher | 1.15.1 | 1.15.2 | ExplicitImports refactor (bare `using X` → explicit lists; verified the newly-explicit symbols were already reachable via the existing `@reexport using BoundaryValueDiffEqCore`), unused-dep removal (`PreallocationTools`, `RecursiveArrayTools`), QA test migration from Aqua to SciMLTesting. No behavior change. |
| BoundaryValueDiffEqCore | 2.7.2 | 2.7.3 | "Document public API coverage" — docstrings only, verified no new exported symbols and no signature changes. Plus QA migration to SciMLTesting v2.1. |
| BoundaryValueDiffEqFIRK | 1.17.1 | 1.17.2 | ExplicitImports refactor, unused dep/import cleanup (verified each removed import is unused in current source), cosmetic removal of an unconstrained type parameter (`deriv::D ... where {D}` → `deriv`) in interpolation dispatch methods, QA migration. |
| BoundaryValueDiffEqMIRK | 1.17.1 | 1.17.2 | ExplicitImports refactor plus two real bug fixes to the existing constrained-optimization MIRK code path: "Allow constrained MIRK without f_prototype" and "Fix MIRK constrained interpolation without controls" (control-variable derivative interpolation), with new regression tests (`dynamic_optimization_tests.jl`). The `constraint`/optimization feature already existed prior to this changeset — this is a bug fix, not new public API. |
| BoundaryValueDiffEqMIRKN | 1.16.1 | 1.16.2 | ExplicitImports refactor, unused dep removal (`ArrayInterface`, `BandedMatrices`, `FastAlmostBandedMatrices`, `PrecompileTools`, `SparseArrays` — verified no remaining usages), QA migration. |
| BoundaryValueDiffEqShooting | 1.17.2 | 1.17.3 | No `src/` changes at all — compat floor raise (`SciMLTesting`) and QA test migration only. |

## Compat floor cascade analysis

For every sibling package `S` depending on a bumped package `P`, checked whether `S`'s source uses anything from `P` that only exists starting at `P`'s new version:

- **Core → {Ascher, FIRK, MIRK, MIRKN, Shooting}**: Core's only change is docstring additions (no new exported symbols, no signature changes), so no sibling needs its Core compat floor raised.
- All sibling packages' existing compat floors on Core (`"2.0"` or `"2.2"`) and root's floors on all `lib/*` packages (`"1"` for the 1.x libs, `"2"` for Core) are open-ended-enough to already cover these new patch versions without edits.

Net result: **no `[compat]` section changes were required**, only the `version` field bump in each package's own `Project.toml`.

## Test plan
- [x] Diffed each package's own subtree since its last-registered version's git-tree-sha1 (matched against JuliaRegistries/General `Versions.toml`) to scope the review correctly
- [x] Verified every newly-explicit import resolves to the same underlying symbol it did implicitly before (checked `@reexport` chains and Core's export list)
- [x] Verified every removed dependency/import has no remaining usage in current source
- [x] Confirmed the MIRK behavior change is a bug fix to pre-existing functionality (present before this changeset), not new public API
- [ ] CI on this PR (root + sublibrary matrices, downgrade, QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)