### PR TITLE
Use finite-difference AD for BVP default nonlinear solvers

### DIFF
--- a/lib/BoundaryValueDiffEqCore/src/default_internal_solve.jl
+++ b/lib/BoundaryValueDiffEqCore/src/default_internal_solve.jl
@@ -6,7 +6,7 @@
 # resolved
 function __FastShortcutBVPCompatibleNLLSPolyalg(
         ::Type{T} = Float64; concrete_jac = nothing,
-        linsolve = nothing, autodiff = nothing, kwargs...
+        linsolve = nothing, autodiff = AutoFiniteDiff(), kwargs...
     ) where {T}
     if T <: Complex
         algs = (
@@ -30,7 +30,7 @@ end
 
 function __FastShortcutBVPCompatibleNonlinearPolyalg(
         ::Type{T} = Float64; concrete_jac = nothing,
-        linsolve = nothing, autodiff = nothing
+        linsolve = nothing, autodiff = AutoFiniteDiff()
     ) where {T}
     if T <: Complex
         algs = (NewtonRaphson(; concrete_jac, linsolve, autodiff),)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

This changes the internal BVP-compatible default nonlinear solver polyalgorithms to use `AutoFiniteDiff()` when no autodiff backend is specified.

The master downgrade failures were coming from the downgraded NonlinearSolve stack selecting ForwardDiff through these internal defaults, which propagated dual numbers into user boundary-condition residual arrays and failed with `Float64(::ForwardDiff.Dual...)`.

## Validation

- `git diff --check`
- Runic: `julia +1 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/runic_env -e 'using Runic; exit(Runic.main(["--check", "--verbose", "."]))'` checked 110 files successfully.
- Downgraded Shooting Core on Julia 1.10 after rebasing onto `e2b50b00`: `BoundaryValueDiffEqShooting tests passed` with `Shooting Basic Problems Tests | 82 pass`, `Shooting NLLS Tests | 56 pass`, and `Shooting Orbital Tests | 40 pass`.
- Downgraded MIRK Core on Julia 1.10 after rebasing onto `e2b50b00`: `BoundaryValueDiffEqMIRK tests passed` with `MIRK Basic Tests | 200 pass`, `MIRK NLLS Tests | 72 pass`, `MIRK Ensemble Tests | 10 pass`, `MIRK Singular BVP Tests | 8 pass`, `MIRK VectorOfVector Initials Tests | 2 pass`, and `MIRK Dynamic Optimization Tests | 6 pass`.
- After PR creation, `master` advanced to `4dfc3ef2` via release-prep version-only `Project.toml` bumps. I rebased over that and reran `git diff --check` plus Runic successfully.

Master-failure investigation: reproduced on clean master and bisected the Shooting downgrade failure to `fe630c867aae5706a2e2a6edd1967519ec3c91f8`, where the SciMLBase compat floor moved the downgraded stack to SciMLBase 3.30 / NonlinearSolveBase 2.33 / NonlinearSolveFirstOrder 2.1+.