### PR TITLE
Target ModelingToolkitBase in downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -17,11 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: ModelingToolkit.jl, group: All}
+          - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII, subdir: lib/ModelingToolkitBase, upstream_subdirs: "lib/BoundaryValueDiffEqCore,lib/BoundaryValueDiffEqMIRK,lib/BoundaryValueDiffEqAscher"}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
+      upstream-subdirs: "${{ matrix.package.upstream_subdirs }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1.11"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

- point the ModelingToolkit downstream row at `lib/ModelingToolkitBase`, where the relevant boundary-value problem tests now live
- run the `InterfaceII` group containing `test/bvproblem.jl`
- develop the local `BoundaryValueDiffEqCore`, `BoundaryValueDiffEqMIRK`, and `BoundaryValueDiffEqAscher` projects into that target environment so monorepo changes are actually exercised

This caller depends on SciML/.github#115 being merged and the shared `v1` tag being advanced, because it uses the new `upstream-subdirs` input.

## Local verification

- `actionlint .github/workflows/Downstream.yml` — passed
- `julia +1.12 --startup-file=no -m Runic --check .` — passed
- `git diff --check` — passed
- exact Julia 1.11 rehearsal of the proposed `InterfaceII` target with all three source subprojects developed — the target manifest contained path entries for all three local packages and the intended suite ran for 60m29s: **7,233 passed, 3 errored, 4 pre-existing broken**

The three errors are real MIRK/optimization compatibility failures in the existing source (`Lotka-Volterra`, cost-function compilation, and parameter estimation), not resolver handling or a silent no-op. They are being investigated independently on a clean `master` checkout; this focused workflow PR does not hide or weaken them.

**Please ignore this draft until it has been reviewed by @ChrisRackauckas.**