### PR TITLE
Bump BoundaryValueDiffEq subpackage versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.23.1"
+version = "5.23.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.3"
+version = "2.7.4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps the following subpackages so their accumulated unreleased `src/` changes can be registered:

- `BoundaryValueDiffEq` v5.23.1 → **v5.23.2** (patch) — Merge pull request #564 from ChrisRackauckas-Claude/agent/scimltesting-2.4-boundaryvaluediffeq (docs/QA/compat/internal; no public API or behavior break)
- `BoundaryValueDiffEqCore` v2.7.3 → **v2.7.4** (patch) — QA: migrate BoundaryValueDiffEq to SciMLTesting 2.4 (docs/QA/compat/internal; no public API or behavior break)

Each bump reflects the semantic level of its diff (patch unless new public API was added). Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)