### PR TITLE
Fix MIRK Dual-eltype error in EvalSol during residual AD (#566)

### DIFF
--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.2"
+version = "1.17.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/src/BoundaryValueDiffEqMIRK.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/BoundaryValueDiffEqMIRK.jl
@@ -42,7 +42,7 @@ using SciMLBase: SciMLBase, AbstractDiffEqInterpolation, BVPFunction, BVProblem,
     __solve, isinplace, remake, solve
 using Setfield: @set!
 using Reexport: @reexport
-using PreallocationTools: PreallocationTools, get_tmp
+using PreallocationTools: PreallocationTools, get_tmp, LazyBufferCache
 using PrecompileTools: @compile_workload, @setup_workload
 using Preferences: Preferences
 using SparseArrays: sparse

--- a/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/interpolation.jl
@@ -380,11 +380,26 @@ always update the intermediate solution with discrete solution + discrete stages
 (Continuous MIRK: u(meshᵢ + τ*dt) = yᵢ + dt sum br(τ)*kr).
 """
 @views function update_eval_sol!(eval_sol::EvalSol, y_, cache::MIRKCache)
-    eval_sol.u[1:end] .= __restructure_sol(y_, cache.in_size)
+    restructured = __restructure_sol(y_, cache.in_size)
     eval_sol.cache.k_discrete[1:end] .= cache.k_discrete
     eval_sol.cache.k_interp.u[1:end] .= cache.k_interp.u
     interp_setup!(eval_sol.cache)
-    return nothing
+    # On an ordinary residual evaluation `y_` matches `eval_sol.u`'s element type, so the
+    # preallocated buffer is updated in place (works for e.g. StaticArray states too).
+    if promote_type(eltype(eltype(restructured)), eltype(eltype(eval_sol.u))) ===
+            eltype(eltype(eval_sol.u))
+        eval_sol.u[1:end] .= restructured
+        return eval_sol
+    end
+    # When the residual is differentiated directly (e.g. a line-search directional
+    # derivative), `y_` carries ForwardDiff.Duals that cannot be written into the Float64
+    # buffer. The lazy cache hands back a matching-eltype buffer, allocated once per eltype
+    # and reused afterwards. On this path `y_` is DiffCache-backed (plain Arrays), so the
+    # VectorOfArray buffer is safe to allocate via `similar`.
+    voa = VectorOfArray(restructured)
+    u = get_tmp(cache.eval_sol_cache, voa)
+    u .= voa
+    return EvalSol(u.u, eval_sol.t, cache)
 end
 
 """

--- a/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/mirk.jl
@@ -37,6 +37,11 @@
     optimize_kwargs
     kwargs
     verbose
+    # Element-type-adaptive buffer for the boundary-condition EvalSol. The residual can
+    # be differentiated directly (e.g. a line-search directional derivative), so the
+    # solution handed to the BCs may carry ForwardDiff.Duals; the lazy cache allocates a
+    # matching-eltype buffer on demand and reuses it across calls.
+    eval_sol_cache
 end
 
 Base.eltype(::MIRKCache{iip, T, use_both}) where {iip, T, use_both} = T
@@ -254,7 +259,8 @@ function SciMLBase.__init(
         alg_order(alg), stage, N, size(u0), f, bc, prob_, prob.problem_type, prob.p, alg,
         TU, ITU, f_prototype, bcresid_prototype, mesh, mesh_dt, k_discrete, k_interp, y,
         y₀, y₀_flat, residual, fᵢ_cache, fᵢ₂_cache, errors, new_stages, resid₁_size, prob.singular_term
-        , nlsolve_kwargs, optimize_kwargs, (; abstol, dt, adaptive, controller, tune_parameters, kwargs...), verbose_spec
+        , nlsolve_kwargs, optimize_kwargs, (; abstol, dt, adaptive, controller, tune_parameters, kwargs...), verbose_spec,
+        LazyBufferCache()
     )
 end
 
@@ -469,7 +475,7 @@ end
     y_ = recursive_unflatten!(y, u)
     resids = [get_tmp(r, u) for r in residual]
     Φ!(resids[2:end], cache, y_, u, trait, constraint)
-    update_eval_sol!(eval_sol, y_, cache)
+    eval_sol = update_eval_sol!(eval_sol, y_, cache)
     eval_bc_residual!(resids[1], pt, bc!, eval_sol, p, mesh)
     recursive_flatten!(resid, resids)
     return nothing
@@ -481,7 +487,7 @@ end
     ) where {BC}
     y_ = recursive_unflatten!(y, u)
     Φ!(residual[2:end], cache, y_, u, trait, constraint)
-    update_eval_sol!(eval_sol, y_, cache)
+    eval_sol = update_eval_sol!(eval_sol, y_, cache)
     eval_bc_residual!(residual[1], pt, bc!, eval_sol, p, mesh)
     recursive_flatten!(resid, residual)
     return nothing
@@ -541,7 +547,7 @@ end
     ) where {BC}
     y_ = recursive_unflatten!(y, u)
     resid_co = Φ(cache, y_, u, trait)
-    update_eval_sol!(eval_sol, y_, cache)
+    eval_sol = update_eval_sol!(eval_sol, y_, cache)
     resid_bc = eval_bc_residual(pt, bc, eval_sol, p, mesh)
     return vcat(resid_bc, mapreduce(vec, vcat, resid_co))
 end

--- a/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/Core/mirk_basic_tests.jl
@@ -793,3 +793,49 @@ end
     sol3 = solve(bvp3, MIRK5(), dt = 0.1, adaptive = false)
     @test SciMLBase.successful_retcode(sol3)
 end
+
+# The boundary conditions evaluate the solution object (`u(t)`), so the residual holds
+# a preallocated `EvalSol`. When the nonlinear solver differentiates the residual
+# directly (e.g. a line-search directional derivative), the flattened solution carries
+# `ForwardDiff.Dual`s that must not be written into the `Float64` `EvalSol` buffer. This
+# reproduces the geodesic BVP on an embedded torus from Manifolds.jl (`solve_chart_log_bvp`).
+@testset "Solution-object BC survives Dual residual (issue 566)" begin
+    using SciMLBase
+
+    R, r = 3.0, 2.0
+    function affine_connection(a, Xc, Yc)
+        θ = a[1]
+        sinθ, cosθ = sincos(θ)
+        Γ¹₂₂ = (R + r * cosθ) * sinθ / r
+        Γ²₁₂ = -r * sinθ / (R + r * cosθ)
+        return (Xc[2] * Γ¹₂₂ * Yc[2], Γ²₁₂ * (Xc[1] * Yc[2] + Xc[2] * Yc[1]))
+    end
+    function chart_log_problem!(du, u, p, t)
+        a = @view u[1:2]
+        dx = @view u[3:4]
+        ddx = affine_connection(a, dx, dx)
+        du[1] = dx[1]
+        du[2] = dx[2]
+        du[3] = -ddx[1]
+        du[4] = -ddx[2]
+        return du
+    end
+
+    a1 = [π / 2, -1.0]
+    a2 = [-π / 8, π / 2]
+    function bc1!(residual, u, p, t)
+        ua = u(0.0)
+        ub = u(1.0)
+        residual[1] = ua[1] - a1[1]
+        residual[2] = ua[2] - a1[2]
+        residual[3] = ub[1] - a2[1]
+        residual[4] = ub[2] - a2[2]
+        return residual
+    end
+    u0 = (p, t) -> vcat(a1 .+ t .* (a2 .- a1), zero(a1))
+    bvp = BVProblem(chart_log_problem!, bc1!, u0, (0.0, 1.0))
+    sol = solve(bvp, MIRK4(); dt = 0.05)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1][1:2] ≈ a1
+    @test sol.u[end][1:2] ≈ a2
+end


### PR DESCRIPTION
## Summary

Fixes #566 — `Manifolds.jl` chart BVP (`solve_chart_log_bvp`) with `MIRK4` throws
`MethodError: no method matching Float64(::ForwardDiff.Dual{…})`.

**Please ignore until reviewed by @ChrisRackauckas.**

## Root cause

When the boundary conditions evaluate the solution object (`u(t)`), the MIRK residual
keeps a preallocated, `Float64`-typed `EvalSol`. The residual `loss` (the combined
`__mirk_loss`/`__mirk_loss!` for `StandardBVProblem`) is normally called with `Float64`
`u`, with Jacobians computed by the separate split `loss_bc`/`loss_collocation` closures.

However, the nonlinear solver can differentiate the residual *directly* — the
`BackTracking` line search computes a directional derivative of the residual via a
ForwardDiff JVP (`SciMLJacobianOperators` → `DifferentiationInterface` pushforward).
On that path `y_ = recursive_unflatten!(y, u)` carries `ForwardDiff.Dual`s, and
`update_eval_sol!` tried to broadcast those Duals into the `Float64` `eval_sol.u`
buffer:

```
eval_sol.u[1:end] .= __restructure_sol(y_, cache.in_size)   # Dual -> Float64 buffer
```

which throws the reported `MethodError`. The stage buffers (`k_discrete`, `k_interp`,
`new_stages`) already handle Duals through their `DiffCache` `.du` fields; `eval_sol.u`
was the only buffer that could not.

## Fix

`update_eval_sol!` now branches on element type:

- **Ordinary residual evaluation** (`y_` matches `eval_sol.u`'s eltype): the preallocated
  buffer is updated in place, exactly as before. This keeps the common path zero-alloc and
  correct for StaticArray (`MVector`) states, which do not survive `similar` on a
  `VectorOfArray`.
- **Residual differentiated directly** (`y_` carries `Dual`s): the buffer comes from a
  `LazyBufferCache` stored on the `MIRKCache`. `get_tmp` returns a matching-eltype buffer,
  allocated once per eltype and reused thereafter, with no `DiffCache` chunk-size coupling.
  On this path `y_` is `DiffCache`-backed (plain `Array`s), so the `VectorOfArray` buffer is
  safe to allocate.

`update_eval_sol!` returns the (possibly Dual) `EvalSol`, and the three `StandardBVProblem`
loss closures rebind `eval_sol` to it. The stage buffers (`k_discrete`, `k_interp`,
`new_stages`) already handle Duals via their `DiffCache` `.du` fields; this brings
`eval_sol` in line.

## Verification

- Reproduced the exact issue MRE end-to-end (`Manifolds` + `OrdinaryDiffEq` +
  `BoundaryValueDiffEqMIRK`, Julia 1.12.6): fails on `master`, succeeds after the fix
  with the boundary conditions satisfied (`γ(0) = a1`, `γ(1) = a2`).
- Added a **`Manifolds`-free** regression test (`Core/mirk_basic_tests.jl`) that
  reproduces the torus geodesic BVP. It throws the same `MethodError` on `master` and
  passes with the fix.
- Ran the MIRK `Core` test group locally: the only failure is a **pre-existing** one on
  `master` (the `optimize` test at `mirk_basic_tests.jl:584`, an OptimizationBase↔
  OptimizationIpopt version mismatch unrelated to this change). Simple Pendulum
  (`MVector` states, interior-interpolation BC) and all other Core tests pass.

## Note (not fixed here)

`BoundaryValueDiffEqFIRK` (`firk.jl`) and `BoundaryValueDiffEqMIRKN` (`mirkn.jl`) contain
the same `eval_sol.u[1:end] .= …` pattern and share the latent bug. Left out to keep this
PR focused on the reported `MIRK` regression; can follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
