### PR TITLE
Bump 7 package versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.23.2"
+version = "5.23.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.2"
+version = "1.15.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.4"
+version = "2.7.5"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.2"
+version = "1.17.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.3"
+version = "1.17.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.16.2"
+version = "1.16.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.3"
+version = "1.17.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
        These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
        tree recorded in the General registry for their current version, but the version was never
        bumped — so the changes cannot be released.

        | package | from | to | kind | why |
        |---|---|---|---|---|
        | `BoundaryValueDiffEq` | 5.23.2 | **5.23.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqAscher` | 1.15.2 | **1.15.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqCore` | 2.7.4 | **2.7.5** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqFIRK` | 1.17.2 | **1.17.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqMIRK` | 1.17.3 | **1.17.4** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqMIRKN` | 1.16.2 | **1.16.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `BoundaryValueDiffEqShooting` | 1.17.3 | **1.17.4** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

        ### How the versions were chosen

        Patch by default. A package was promoted to a **minor** bump only where it gained public API
        or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
        in the patch position regardless of what they added.

        No package in this PR needs a major bump: comparing the exported/`@public` name sets between
        each package's released commit and master, **no name that the package itself defines was
        removed**. The removals that do appear are blanket reexports of names owned by other packages
        (e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
        SciML does not treat as documented public API.

        Registration follows once this merges.

        ---

        Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
