### PR TITLE
Fix docs imports after subpackage reexport cleanup

### DIFF
--- a/docs/src/tutorials/optimal_control.md
+++ b/docs/src/tutorials/optimal_control.md
@@ -159,7 +159,9 @@ The inequality constraints for the state variables and control variables are:
 Similar solving for such optimal control problem can be found on JuMP.jl and InfiniteOpt.jl. The detailed parameters are taken from [COPS](https://www.mcs.anl.gov/%7Emore/cops/cops3.pdf).
 
 ```@example rocket_launch
-using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots
+using BoundaryValueDiffEqMIRK: MIRK4
+using SciMLBase: BVPFunction, BVProblem, solve
+using OptimizationIpopt, Plots
 h_0 = 1                      # Initial height
 v_0 = 0                      # Initial velocity
 m_0 = 1.0                    # Initial mass
@@ -278,7 +280,9 @@ The target cost function is defined as the "energy" so the target cost function 
 ```
 
 ```@example cart_pole
-using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots
+using BoundaryValueDiffEqMIRK: MIRK4
+using SciMLBase: BVPFunction, BVProblem, solve
+using OptimizationIpopt, Plots
 m_1 = 1.0                      # Cart mass
 m_2 = 0.3                      # Pole mass
 l = 0.5                        # Pole length

--- a/lib/BoundaryValueDiffEqMIRKN/src/algorithms.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/algorithms.jl
@@ -47,6 +47,8 @@ for order in (4, 6)
         ## Examples
 
         ```jldoctest
+        julia> using BoundaryValueDiffEqMIRKN: MIRKN$($order)
+
         julia> MIRKN$($order)().max_num_subintervals
         3000
         ```


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- import MIRKN algorithms directly in their generated doctests
- import MIRK4 and SciMLBase BVP APIs directly in the optimal-control examples

## Clean-master reproduction

Current `master` (`e19380d`) fails full docs because `MIRKN4`/`MIRKN6` are undefined. A targeted doctest bisect identifies `03b00311222660d12f08df74e0fa77e5a386a785` as the first bad commit; its parent `219b50219a763f832516ef2d6131278f8cd58257` passes. Fixing that exposes the same direct-import issue in two rendered MIRK examples.

## Validation

- targeted MIRKN doctests: release and Julia 1.10
- full rendered docs and doctests: release and Julia 1.10
- Runic on all tracked Julia files
- `git diff --check`