### PR TITLE
Resolve documentation against local subpackages

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -21,6 +21,15 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleBoundaryValueDiffEq = "be0294bd-f90f-4760-ac4e-3421ce2b2da0"
 
+[sources]
+BoundaryValueDiffEq = {path = ".."}
+BoundaryValueDiffEqAscher = {path = "../lib/BoundaryValueDiffEqAscher"}
+BoundaryValueDiffEqCore = {path = "../lib/BoundaryValueDiffEqCore"}
+BoundaryValueDiffEqFIRK = {path = "../lib/BoundaryValueDiffEqFIRK"}
+BoundaryValueDiffEqMIRK = {path = "../lib/BoundaryValueDiffEqMIRK"}
+BoundaryValueDiffEqMIRKN = {path = "../lib/BoundaryValueDiffEqMIRKN"}
+BoundaryValueDiffEqShooting = {path = "../lib/BoundaryValueDiffEqShooting"}
+
 [compat]
 ADTypes = "1.9"
 BoundaryValueDiffEq = "5.13.0"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary
- declare the repository root and all six in-tree subpackages as documentation environment path sources
- ensure docs and doctests exercise the checked-out branch instead of registry releases

## Validation
- verified `pathof(BoundaryValueDiffEqMIRKN)` resolves inside this checkout
- MIRKN doctest: 1 passed
- Runic 1.7.0 `--check` over every tracked Julia file
- `git diff --check`