### PR TITLE
Fix wrapper tests to use local package sources

### DIFF
--- a/test/wrappers/Project.toml
+++ b/test/wrappers/Project.toml
@@ -15,6 +15,15 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources]
+BoundaryValueDiffEq = {path = "../.."}
+BoundaryValueDiffEqAscher = {path = "../../lib/BoundaryValueDiffEqAscher"}
+BoundaryValueDiffEqCore = {path = "../../lib/BoundaryValueDiffEqCore"}
+BoundaryValueDiffEqFIRK = {path = "../../lib/BoundaryValueDiffEqFIRK"}
+BoundaryValueDiffEqMIRK = {path = "../../lib/BoundaryValueDiffEqMIRK"}
+BoundaryValueDiffEqMIRKN = {path = "../../lib/BoundaryValueDiffEqMIRKN"}
+BoundaryValueDiffEqShooting = {path = "../../lib/BoundaryValueDiffEqShooting"}
+
 [compat]
 BoundaryValueDiffEq = "5"
 BoundaryValueDiffEqAscher = "1"


### PR DESCRIPTION
## Summary

- add local source overrides for the umbrella package and all wrapper-tested subpackages
- keep prerelease wrapper tests on the checked-out repository instead of registered releases

## Verification

- release wrapper group: 6/6 passed
- Julia 1.10 wrapper group: 6/6 passed
- prerelease wrapper group: 6/6 passed
- all tracked Julia files pass Runic 1.7.0
- `git diff --check` passes

Bisected from the clean-master prerelease failure to `88a76d1c3b476c6821a40d1a03fc21b0e3db420c`.

Ignore this PR until it has been reviewed by @ChrisRackauckas.