### PR TITLE
Restore the FIRK AD local Core source

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/test/AD/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/test/AD/Project.toml
@@ -8,6 +8,9 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources]
+BoundaryValueDiffEqCore = {path = "../../../BoundaryValueDiffEqCore"}
+
 [compat]
 BoundaryValueDiffEqCore = "2"
 BoundaryValueDiffEqFIRK = "1"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Restore the BoundaryValueDiffEqCore path source in the FIRK AD test environment. This keeps prerelease resolution on the checked-out in-repo Core package, consistent with the other test environments.

This is a separate clean-master CI repair found while auditing #579. It does not change #579.

## Reproduction and history

- Clean master on Julia 1.13.0-rc1 fails before tests: `could not find source path for package BoundaryValueDiffEqCore`.
- History search identifies `a5af442db7f3927ffcb4cb8a2d4b28b5576022b2` as the first bad repository commit: the SciMLTesting 2.4 migration removed the pre-existing Core source entry.

## Verification

- With only this source entry restored, Julia 1.13.0-rc1 resolves and develops the in-repo Core package, loads FIRK, and enters the AD tests.
- Result after setup: 7 passed, 2 errored. Both errors are the separate known Mooncake `uppercase(::Char)` prerelease failure tracked in #543 and addressed for FIRK by draft #557; this PR does not hide or change them.
- Runic 1.7.0 over every tracked Julia file: passed.
- git diff --check: passed.