### PR TITLE
Bump Core patch version after compat update

### DIFF
--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.7.5"
+version = "2.7.6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary
- bump `BoundaryValueDiffEqCore` from `2.7.5` to `2.7.6` after #597 changed its compatibility metadata
- prevent Julia 1.12 Pkg from combining the registered `2.7.5` tree hash with the local Core source path when validating the owner-direct dependency graph in #579

## Testing
- Core group, Julia release: 20/20 passed
- Core group, Julia 1.10: 20/20 passed
- Julia 1.12 resolver probe with the #579 FIRK dependency graph: passed and selected local Core `2.7.6`
- Runic 1.7.0: all 120 tracked Julia files passed
- strict QA release: 19/20; strict QA Julia 1.10: 17/18; the sole failure on both is the independently reproduced clean-master reexport drift tracked by #598 (`PostconditionSpace`, `PostconditionSpecifier`)

This release-metadata repair is intentionally separate from #579.