### PR TITLE
Set sequential release versions

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.3"
+version = "1.18.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.16.3"
+version = "1.16.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| BoundaryValueDiffEqFIRK | 1.17.3 | 1.17.3 | 1.18.0 | minor |
| BoundaryValueDiffEqMIRKN | 1.16.3 | 1.16.3 | 1.16.4 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / Quality Assurance |   20     20  2m05.6s / Testing BoundaryValueDiffEq tests passed`
- `GROUP=BoundaryValueDiffEqFIRK /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:             | Pass  Total      Time / FIRK Expanded Basic Tests |  126    126  31m15.3s / Test Summary:           | Pass  Total      Time / FIRK Nested Basic Tests |  100    100  27m10.2s / Testing BoundaryValueDiffEq tests passed`
- `GROUP=BoundaryValueDiffEqFIRK_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / Quality Assurance |   20     20  1m52.8s / Testing BoundaryValueDiffEq tests passed`
- `GROUP=BoundaryValueDiffEqMIRKN /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total      Time / MIRKN Basic Tests |   25     25  12m54.6s / Testing BoundaryValueDiffEq tests passed`
- `GROUP=BoundaryValueDiffEqMIRKN_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / Quality Assurance |   20     20  1m23.5s / Testing BoundaryValueDiffEq tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude lib/BoundaryValueDiffEqFIRK/Project.toml lib/BoundaryValueDiffEqMIRKN/Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- BoundaryValueDiffEqCore: `@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqCore`
- BoundaryValueDiffEqFIRK: `@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqFIRK`
- BoundaryValueDiffEqMIRKN: `@JuliaRegistrator register subdir=lib/BoundaryValueDiffEqMIRKN`