### PR TITLE
Restore the documented reexport surface across the BVP packages

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -16,7 +16,7 @@ pages = [
         "solvers/mirk.md", "solvers/firk.md", "solvers/shooting.md", "solvers/mirkn.md",
         "solvers/ascher.md", "solvers/simple_solvers.md", "solvers/wrappers.md",
     ],
-    "API" => Any["api/odeinterface.md"],
+    "API" => Any["api/reexports.md", "api/odeinterface.md"],
     "Development Documentation" => Any["devdocs/internal_interfaces.md"],
     "References" => "references.md",
 ]

--- a/docs/src/api/reexports.md
+++ b/docs/src/api/reexports.md
@@ -1,0 +1,150 @@
+# [Reexported API](@id reexports)
+
+Each BoundaryValueDiffEq package exports a small, deliberate slice of the SciML common
+interface on top of its own solver algorithms, so that `using BoundaryValueDiffEq` (or
+`using` a single solver sublibrary) is enough to write the documented workflow without a
+second import line. None of these names are owned or documented here — this page says
+what each package forwards and who owns it, so you know where to go for the real
+documentation.
+
+The lists below are kept in sync with the reexport `export` block in each package's
+`src/<Package>.jl` and with the approved allow-lists in `test/qa/reexports.jl`, which the
+QA suite checks on every run.
+
+Owners linked from this page:
+
+  - [SciMLBase](https://docs.sciml.ai/SciMLBase/stable/) — problem, function and solution
+    types and the `solve`/`init`/`remake` interface.
+  - [ADTypes](https://sciml.github.io/ADTypes.jl/stable/) — the `Auto*` automatic
+    differentiation backend selectors.
+  - [NonlinearSolveFirstOrder](https://docs.sciml.ai/NonlinearSolve/stable/) — the
+    nonlinear solver algorithms accepted by every solver's `nlsolve` keyword.
+  - `BoundaryValueDiffEqCore` — the shared BVP configuration types, documented under
+    [Automatic Differentiation Backends](@ref),
+    [Error Control Adaptivity](@ref error_control),
+    [Verbosity Control](@ref) and
+    [Common Solver Options (Solve Keyword Arguments)](@ref solver_options).
+
+## BoundaryValueDiffEq
+
+`using BoundaryValueDiffEq` reexports the solver algorithms of every sublibrary
+(`MIRK2`–`MIRK6`, `RadauIIa*`, `LobattoIII*`, `MIRKN4`/`MIRKN6`, `Ascher1`–`Ascher7`,
+`Shooting`, `MultipleShooting`, plus `maxsol`/`minsol` and the ODEInterface wrappers),
+and in addition:
+
+  - AD backend selectors, from ADTypes: `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`,
+    `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse`
+  - Jacobian and verbosity configuration, from BoundaryValueDiffEqCore:
+    `BVPJacobianAlgorithm`, `BVPVerbosity`, `DEFAULT_VERBOSE`
+  - Error control adaptivity, from BoundaryValueDiffEqCore: `DefectControl`,
+    `GlobalErrorControl`, `SequentialErrorControl`, `HybridErrorControl`, `NoErrorControl`,
+    `HOErrorControl`, `REErrorControl`
+  - Cost functionals, from BoundaryValueDiffEqCore: `integral`
+  - Problems, from SciMLBase: `BVProblem`, `TwoPointBVProblem`, `SecondOrderBVProblem`,
+    `TwoPointSecondOrderBVProblem`, `EnsembleProblem`
+  - Functions, from SciMLBase: `BVPFunction`, `DynamicalBVPFunction`, `ODEFunction`
+  - Solving, from SciMLBase: `solve`, `solve!`, `init`, `remake`
+  - Ensemble algorithms for `MultipleShooting`, from SciMLBase: `EnsembleSerial`,
+    `EnsembleThreads`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## BoundaryValueDiffEqMIRK and BoundaryValueDiffEqFIRK
+
+In addition to `MIRK2`–`MIRK6`, `MIRK6I`, `maxsol`, `minsol` (MIRK) and the `RadauIIa*` /
+`LobattoIII*` algorithms (FIRK), both packages reexport:
+
+  - AD backend selectors, from ADTypes: `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`,
+    `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse`
+  - Configuration, from BoundaryValueDiffEqCore: `BVPJacobianAlgorithm`, `BVPVerbosity`,
+    `DEFAULT_VERBOSE`, `integral`
+  - Error control adaptivity, from BoundaryValueDiffEqCore: `DefectControl`,
+    `GlobalErrorControl`, `SequentialErrorControl`, `HybridErrorControl`, `NoErrorControl`,
+    `HOErrorControl`, `REErrorControl`
+  - Inner nonlinear solvers for the `nlsolve` keyword, from NonlinearSolveFirstOrder:
+    `GaussNewton`, `LevenbergMarquardt`, `NewtonRaphson`, `TrustRegion`
+  - Problems and functions, from SciMLBase: `BVProblem`, `TwoPointBVProblem`,
+    `EnsembleProblem`, `BVPFunction`, `ODEFunction`
+  - Solving, from SciMLBase: `solve`, `solve!`, `init`, `remake`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## BoundaryValueDiffEqAscher
+
+In addition to `Ascher1`–`Ascher7`, the same set as MIRK and FIRK, except that Ascher
+documents no ensemble workflow and so does not reexport `EnsembleProblem` or
+`ODEFunction`:
+
+  - AD backend selectors, from ADTypes: `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`,
+    `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse`
+  - Configuration, from BoundaryValueDiffEqCore: `BVPJacobianAlgorithm`, `BVPVerbosity`,
+    `DEFAULT_VERBOSE`, `integral`
+  - Error control adaptivity, from BoundaryValueDiffEqCore: `DefectControl`,
+    `GlobalErrorControl`, `SequentialErrorControl`, `HybridErrorControl`, `NoErrorControl`,
+    `HOErrorControl`, `REErrorControl`
+  - Inner nonlinear solvers, from NonlinearSolveFirstOrder: `GaussNewton`,
+    `LevenbergMarquardt`, `NewtonRaphson`, `TrustRegion`
+  - Problems and functions, from SciMLBase: `BVProblem`, `TwoPointBVProblem`,
+    `BVPFunction` — the last of which carries the mass matrix for the semi-explicit BVDAE
+    form Ascher solves
+  - Solving, from SciMLBase: `solve`, `solve!`, `init`, `remake`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## BoundaryValueDiffEqMIRKN
+
+MIRKN solves second order boundary value problems, so it reexports the second order
+problem and function types rather than the first order ones, and — having no defect
+control adaptivity — only `NoErrorControl` from the error controllers:
+
+  - AD backend selectors, from ADTypes: `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`,
+    `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse`
+  - Configuration, from BoundaryValueDiffEqCore: `BVPJacobianAlgorithm`, `BVPVerbosity`,
+    `DEFAULT_VERBOSE`, `NoErrorControl`, `integral`
+  - Inner nonlinear solvers, from NonlinearSolveFirstOrder: `GaussNewton`,
+    `LevenbergMarquardt`, `NewtonRaphson`, `TrustRegion`
+  - Problems and functions, from SciMLBase: `SecondOrderBVProblem`,
+    `TwoPointSecondOrderBVProblem`, `DynamicalBVPFunction`
+  - Solving, from SciMLBase: `solve`, `solve!`, `init`, `remake`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## BoundaryValueDiffEqShooting
+
+Shooting reduces the BVP to initial value problems, so it reexports `ODEProblem` and the
+ensemble algorithms accepted by `MultipleShooting`'s `ensemblealg` keyword. It is not a
+collocation method and takes no `controller`, so the error control types are not part of
+its surface:
+
+  - AD backend selectors, from ADTypes: `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`,
+    `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse`
+  - Configuration, from BoundaryValueDiffEqCore: `BVPJacobianAlgorithm`, `BVPVerbosity`,
+    `DEFAULT_VERBOSE`, `integral`
+  - Inner nonlinear solvers, from NonlinearSolveFirstOrder: `GaussNewton`,
+    `LevenbergMarquardt`, `NewtonRaphson`, `TrustRegion`
+  - Problems and functions, from SciMLBase: `BVProblem`, `TwoPointBVProblem`,
+    `ODEProblem`, `BVPFunction`
+  - Ensemble algorithms, from SciMLBase: `EnsembleSerial`, `EnsembleThreads`
+  - Solving, from SciMLBase: `solve`, `solve!`, `init`, `remake`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## BoundaryValueDiffEqCore
+
+Core is the shared base the solver sublibraries build on; it owns
+`BVPJacobianAlgorithm`, the error control types, `BVPVerbosity`, `DEFAULT_VERBOSE` and
+`integral`, and forwards:
+
+  - Nonlinear solvers, from NonlinearSolveFirstOrder: `GaussNewton`, `LevenbergMarquardt`,
+    `NewtonRaphson`, `TrustRegion`
+  - Problems, from SciMLBase: `BVProblem`, `TwoPointBVProblem`, `SecondOrderBVProblem`,
+    `TwoPointSecondOrderBVProblem`, `NonlinearProblem`, `NonlinearLeastSquaresProblem`,
+    `OptimizationProblem`
+  - Functions, from SciMLBase: `BVPFunction`, `DynamicalBVPFunction`, `NonlinearFunction`,
+    `OptimizationFunction`
+  - Solving, from SciMLBase: `solve`, `init`, `remake`
+  - Return status, from SciMLBase: `ReturnCode`, `successful_retcode`
+
+## Boundary
+
+These lists are the whole of what these packages forward. Anything else from SciMLBase
+must be imported from SciMLBase directly, anything else from ADTypes from ADTypes, and
+anything else from NonlinearSolve from NonlinearSolve. In particular, solution types
+(`ODESolution` and friends), the integrator interface, callbacks and ensemble analysis
+are deliberately not reexported: BVP solvers return a solution object you index and
+interpolate rather than an integrator you step, so those names belong to their owners.

--- a/docs/src/solvers/firk.md
+++ b/docs/src/solvers/firk.md
@@ -7,8 +7,8 @@ using Pkg
 Pkg.add("BoundaryValueDiffEqFIRK")
 ```
 
-`BoundaryValueDiffEqFIRK` provides the BVP problem constructors and `solve` used by its
-documented solver workflow:
+`BoundaryValueDiffEqFIRK` reexports the BVP problem constructors and `solve` used by its
+documented solver workflow (see [Reexported API](@ref reexports)):
 
 ```jldoctest
 using BoundaryValueDiffEqFIRK

--- a/docs/src/solvers/shooting.md
+++ b/docs/src/solvers/shooting.md
@@ -7,13 +7,13 @@ using Pkg
 Pkg.add("BoundaryValueDiffEqShooting")
 ```
 
-Shooting algorithms operate on problem definitions and solver functions owned by SciMLBase,
-and require an ODE algorithm from its owning solver package:
+`BoundaryValueDiffEqShooting` reexports the problem constructors, `solve` and
+`ReturnCode` its documented workflow uses (see [Reexported API](@ref reexports)); the ODE
+algorithm has to come from its own solver package:
 
 ```jldoctest
-using BoundaryValueDiffEqShooting: MultipleShooting, Shooting
+using BoundaryValueDiffEqShooting
 using OrdinaryDiffEqTsit5: Tsit5
-using SciMLBase: BVProblem, ReturnCode, solve
 
 function f!(du, u, p, t)
     du[1] = u[2]

--- a/docs/src/tutorials/optimal_control.md
+++ b/docs/src/tutorials/optimal_control.md
@@ -159,9 +159,7 @@ The inequality constraints for the state variables and control variables are:
 Similar solving for such optimal control problem can be found on JuMP.jl and InfiniteOpt.jl. The detailed parameters are taken from [COPS](https://www.mcs.anl.gov/%7Emore/cops/cops3.pdf).
 
 ```@example rocket_launch
-using BoundaryValueDiffEqMIRK: MIRK4
-using SciMLBase: BVPFunction, BVProblem, solve
-using OptimizationIpopt, Plots
+using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots
 h_0 = 1                      # Initial height
 v_0 = 0                      # Initial velocity
 m_0 = 1.0                    # Initial mass
@@ -280,9 +278,7 @@ The target cost function is defined as the "energy" so the target cost function 
 ```
 
 ```@example cart_pole
-using BoundaryValueDiffEqMIRK: MIRK4
-using SciMLBase: BVPFunction, BVProblem, solve
-using OptimizationIpopt, Plots
+using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots
 m_1 = 1.0                      # Cart mass
 m_2 = 0.3                      # Pole mass
 l = 0.5                        # Pole length

--- a/lib/BoundaryValueDiffEqAscher/src/BoundaryValueDiffEqAscher.jl
+++ b/lib/BoundaryValueDiffEqAscher/src/BoundaryValueDiffEqAscher.jl
@@ -22,6 +22,21 @@ using ForwardDiff: ForwardDiff
 using LinearAlgebra: LinearAlgebra, I, norm, rank
 using SciMLBase: SciMLBase, BVProblem, ReturnCode, StandardBVProblem,
     TwoPointBVProblem, isinplace, solve
+
+# The public API that BoundaryValueDiffEqAscher reexports (see the second `export` block
+# below), so that `using BoundaryValueDiffEqAscher` on its own is enough to pick an AD
+# backend, build a `BVProblem` or `TwoPointBVProblem` (including the semi-explicit BVDAE
+# form carried by a `BVPFunction` mass matrix), configure the solve, run it, and inspect
+# the result. Every name stays owned and documented by ADTypes, BoundaryValueDiffEqCore,
+# NonlinearSolveFirstOrder or SciMLBase; the set is documented on the Reexported API docs
+# page and approved via `reexports_allow` in test/qa/qa.jl.
+using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake,
+    AutoPolyesterForwardDiff
+using BoundaryValueDiffEqCore: BVPVerbosity, DefectControl, GaussNewton, HOErrorControl,
+    HybridErrorControl, LevenbergMarquardt, NewtonRaphson, NoErrorControl, REErrorControl,
+    SequentialErrorControl, TrustRegion, integral
+using SciMLBase: BVPFunction, init, remake, solve!, successful_retcode
+
 using Setfield: @set!
 
 const DI = DifferentiationInterface
@@ -36,5 +51,18 @@ include("adaptivity.jl")
 include("collocation.jl")
 
 export Ascher1, Ascher2, Ascher3, Ascher4, Ascher5, Ascher6, Ascher7
+
+# Reexported ADTypes / BoundaryValueDiffEqCore / NonlinearSolveFirstOrder / SciMLBase
+# API; approved via `reexports_allow` in test/qa/qa.jl.
+export AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoPolyesterForwardDiff,
+    AutoSparse
+export BVPJacobianAlgorithm, BVPVerbosity, DEFAULT_VERBOSE
+export DefectControl, GlobalErrorControl, SequentialErrorControl, HybridErrorControl,
+    NoErrorControl
+export HOErrorControl, REErrorControl
+export integral
+export GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion
+export BVPFunction, BVProblem, ReturnCode, TwoPointBVProblem, init, remake, solve, solve!,
+    successful_retcode
 
 end # module BoundaryValueDiffEqAscher

--- a/lib/BoundaryValueDiffEqAscher/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqAscher/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting
 using BoundaryValueDiffEqAscher
 using Test
 
+include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))
+
 run_qa(
     BoundaryValueDiffEqAscher;
     ei_kwargs = (;
@@ -12,4 +14,7 @@ run_qa(
         # no public replacement.
         all_qualified_accesses_are_public = (; ignore = (:Dual, :jacobian!)),
     ),
+    reexports_allow = ASCHER_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqAscher, ASCHER_REEXPORTS, @__MODULE__)

--- a/lib/BoundaryValueDiffEqCore/src/BoundaryValueDiffEqCore.jl
+++ b/lib/BoundaryValueDiffEqCore/src/BoundaryValueDiffEqCore.jl
@@ -39,7 +39,7 @@ using SciMLStructures: SciMLStructures
     BVPFunction, BVProblem, DynamicalBVPFunction, NonlinearFunction,
     NonlinearLeastSquaresProblem, NonlinearProblem, OptimizationFunction,
     OptimizationProblem, ReturnCode, SecondOrderBVProblem, TwoPointBVProblem,
-    TwoPointSecondOrderBVProblem, init, remake, solve
+    TwoPointSecondOrderBVProblem, init, remake, solve, successful_retcode
 
 include("verbosity.jl")
 include("types.jl")

--- a/lib/BoundaryValueDiffEqCore/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqCore/test/qa/qa.jl
@@ -36,3 +36,5 @@ run_qa(
     ),
     reexports_allow = CORE_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqCore, CORE_REEXPORTS, @__MODULE__)

--- a/lib/BoundaryValueDiffEqFIRK/src/BoundaryValueDiffEqFIRK.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/BoundaryValueDiffEqFIRK.jl
@@ -46,6 +46,19 @@ using SciMLBase: SciMLBase, AbstractDiffEqInterpolation, BVPFunction, BVProblem,
 using Setfield: @set!
 using SparseArrays: sparse
 using SciMLStructures: SciMLStructures
+
+# The public API that BoundaryValueDiffEqFIRK reexports (see the second `export` block
+# below), so that `using BoundaryValueDiffEqFIRK` on its own is enough to pick an AD
+# backend, build a `BVProblem` or `TwoPointBVProblem`, configure the solve, run it, and
+# inspect the result. Every name stays owned and documented by ADTypes,
+# BoundaryValueDiffEqCore, NonlinearSolveFirstOrder or SciMLBase; the set is documented on
+# the Reexported API docs page and approved via `reexports_allow` in test/qa/qa.jl.
+using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoMooncake, AutoPolyesterForwardDiff
+using BoundaryValueDiffEqCore: BVPVerbosity, GlobalErrorControl, HOErrorControl,
+    HybridErrorControl, NoErrorControl, REErrorControl, SequentialErrorControl, integral
+using NonlinearSolveFirstOrder: NewtonRaphson, TrustRegion
+using SciMLBase: EnsembleProblem, ODEFunction, init, solve!, successful_retcode
+
 using StaticArrays: SMatrix, SVector
 
 const DI = DifferentiationInterface
@@ -308,6 +321,18 @@ export RadauIIa1, RadauIIa2, RadauIIa3, RadauIIa5, RadauIIa7
 export LobattoIIIa2, LobattoIIIa3, LobattoIIIa4, LobattoIIIa5
 export LobattoIIIb2, LobattoIIIb3, LobattoIIIb4, LobattoIIIb5
 export LobattoIIIc2, LobattoIIIc3, LobattoIIIc4, LobattoIIIc5
-export BVProblem, TwoPointBVProblem, solve
+
+# Reexported ADTypes / BoundaryValueDiffEqCore / NonlinearSolveFirstOrder / SciMLBase
+# API; approved via `reexports_allow` in test/qa/qa.jl.
+export AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoPolyesterForwardDiff,
+    AutoSparse
+export BVPJacobianAlgorithm, BVPVerbosity, DEFAULT_VERBOSE
+export DefectControl, GlobalErrorControl, SequentialErrorControl, HybridErrorControl,
+    NoErrorControl
+export HOErrorControl, REErrorControl
+export integral
+export GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion
+export BVPFunction, BVProblem, EnsembleProblem, ODEFunction, ReturnCode, TwoPointBVProblem,
+    init, remake, solve, solve!, successful_retcode
 
 end

--- a/lib/BoundaryValueDiffEqFIRK/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/qa/qa.jl
@@ -21,3 +21,5 @@ run_qa(
     ),
     reexports_allow = FIRK_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqFIRK, FIRK_REEXPORTS, @__MODULE__)

--- a/lib/BoundaryValueDiffEqMIRK/src/BoundaryValueDiffEqMIRK.jl
+++ b/lib/BoundaryValueDiffEqMIRK/src/BoundaryValueDiffEqMIRK.jl
@@ -45,6 +45,18 @@ using PreallocationTools: PreallocationTools, get_tmp, LazyBufferCache
 using PrecompileTools: @compile_workload, @setup_workload
 using Preferences: Preferences
 using SparseArrays: sparse
+
+# The public API that BoundaryValueDiffEqMIRK reexports (see the second `export` block
+# below), so that `using BoundaryValueDiffEqMIRK` on its own is enough to pick an AD
+# backend, build a `BVProblem` or `TwoPointBVProblem`, configure the solve, run it, and
+# inspect the result. Every name stays owned and documented by ADTypes,
+# BoundaryValueDiffEqCore, NonlinearSolveFirstOrder or SciMLBase; the set is documented on
+# the Reexported API docs page and approved via `reexports_allow` in test/qa/qa.jl.
+using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoMooncake, AutoPolyesterForwardDiff
+using BoundaryValueDiffEqCore: BVPVerbosity, NewtonRaphson, NoErrorControl, TrustRegion,
+    integral
+using SciMLBase: EnsembleProblem, ODEFunction, init, solve!, successful_retcode
+
 using SciMLStructures: SciMLStructures
 
 const DI = DifferentiationInterface
@@ -178,5 +190,18 @@ end
 
 export MIRK2, MIRK3, MIRK4, MIRK5, MIRK6, MIRK6I
 export maxsol, minsol
+
+# Reexported ADTypes / BoundaryValueDiffEqCore / NonlinearSolveFirstOrder / SciMLBase
+# API; approved via `reexports_allow` in test/qa/qa.jl.
+export AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoPolyesterForwardDiff,
+    AutoSparse
+export BVPJacobianAlgorithm, BVPVerbosity, DEFAULT_VERBOSE
+export DefectControl, GlobalErrorControl, SequentialErrorControl, HybridErrorControl,
+    NoErrorControl
+export HOErrorControl, REErrorControl
+export integral
+export GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion
+export BVPFunction, BVProblem, EnsembleProblem, ODEFunction, ReturnCode, TwoPointBVProblem,
+    init, remake, solve, solve!, successful_retcode
 
 end

--- a/lib/BoundaryValueDiffEqMIRK/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqMIRK/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting
 using BoundaryValueDiffEqMIRK
 using Test
 
+include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))
+
 run_qa(
     BoundaryValueDiffEqMIRK;
     ei_kwargs = (;
@@ -17,4 +19,7 @@ run_qa(
             ignore = (:Tunable, :canonicalize, :isscimlstructure),
         ),
     ),
+    reexports_allow = MIRK_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqMIRK, MIRK_REEXPORTS, @__MODULE__)

--- a/lib/BoundaryValueDiffEqMIRKN/src/BoundaryValueDiffEqMIRKN.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/src/BoundaryValueDiffEqMIRKN.jl
@@ -31,6 +31,19 @@ using Preferences: Preferences
 using RecursiveArrayTools: AbstractVectorOfArray, ArrayPartition
 using SciMLBase: SciMLBase, ReturnCode, SecondOrderBVProblem,
     StandardSecondOrderBVProblem, TwoPointSecondOrderBVProblem, isinplace, remake
+
+# The public API that BoundaryValueDiffEqMIRKN reexports (see the second `export` block
+# below), so that `using BoundaryValueDiffEqMIRKN` on its own is enough to pick an AD
+# backend, build a `SecondOrderBVProblem` or `TwoPointSecondOrderBVProblem`, configure the
+# solve, run it, and inspect the result. Every name stays owned and documented by ADTypes,
+# BoundaryValueDiffEqCore, NonlinearSolveFirstOrder or SciMLBase; the set is documented on
+# the Reexported API docs page and approved via `reexports_allow` in test/qa/qa.jl.
+using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake,
+    AutoPolyesterForwardDiff
+using BoundaryValueDiffEqCore: BVPVerbosity, GaussNewton, LevenbergMarquardt,
+    NewtonRaphson, TrustRegion, integral
+using SciMLBase: DynamicalBVPFunction, init, solve, solve!, successful_retcode
+
 using Setfield: @set!
 
 const DI = DifferentiationInterface
@@ -44,5 +57,15 @@ include("mirkn_tableaus.jl")
 include("interpolation.jl")
 
 export MIRKN4, MIRKN6
+
+# Reexported ADTypes / BoundaryValueDiffEqCore / NonlinearSolveFirstOrder / SciMLBase
+# API; approved via `reexports_allow` in test/qa/qa.jl.
+export AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoPolyesterForwardDiff,
+    AutoSparse
+export BVPJacobianAlgorithm, BVPVerbosity, DEFAULT_VERBOSE, NoErrorControl
+export integral
+export GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion
+export DynamicalBVPFunction, ReturnCode, SecondOrderBVProblem,
+    TwoPointSecondOrderBVProblem, init, remake, solve, solve!, successful_retcode
 
 end

--- a/lib/BoundaryValueDiffEqMIRKN/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqMIRKN/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting
 using BoundaryValueDiffEqMIRKN
 using Test
 
+include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))
+
 run_qa(
     BoundaryValueDiffEqMIRKN;
     ei_kwargs = (;
@@ -12,4 +14,7 @@ run_qa(
             ignore = (:StandardSecondOrderBVProblem, :pickchunksize),
         ),
     ),
+    reexports_allow = MIRKN_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqMIRKN, MIRKN_REEXPORTS, @__MODULE__)

--- a/lib/BoundaryValueDiffEqShooting/src/BoundaryValueDiffEqShooting.jl
+++ b/lib/BoundaryValueDiffEqShooting/src/BoundaryValueDiffEqShooting.jl
@@ -35,7 +35,19 @@ using Setfield: @set
 using SparseArrays: sparse
 using OrdinaryDiffEqTsit5: Tsit5
 using PrecompileTools: @compile_workload, @setup_workload
+
 using Preferences: Preferences
+
+# The public API that BoundaryValueDiffEqShooting reexports (see the second `export` block
+# below), so that `using BoundaryValueDiffEqShooting` on its own is enough to pick an AD
+# backend, build a `BVProblem` or `TwoPointBVProblem`, configure the solve, run it, and
+# inspect the result. Every name stays owned and documented by ADTypes,
+# BoundaryValueDiffEqCore, NonlinearSolveFirstOrder or SciMLBase; the set is documented on
+# the Reexported API docs page and approved via `reexports_allow` in test/qa/qa.jl.
+using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoMooncake, AutoPolyesterForwardDiff
+using BoundaryValueDiffEqCore: BVPVerbosity, DEFAULT_VERBOSE, GaussNewton,
+    LevenbergMarquardt, NewtonRaphson, TrustRegion, integral
+using SciMLBase: BVPFunction, ReturnCode, init, successful_retcode
 
 const DI = DifferentiationInterface
 
@@ -107,5 +119,15 @@ include("sparse_jacobians.jl")
 end
 
 export Shooting, MultipleShooting
+
+# Reexported ADTypes / BoundaryValueDiffEqCore / NonlinearSolveFirstOrder / SciMLBase
+# API; approved via `reexports_allow` in test/qa/qa.jl.
+export AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoPolyesterForwardDiff,
+    AutoSparse
+export BVPJacobianAlgorithm, BVPVerbosity, DEFAULT_VERBOSE
+export integral
+export GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion
+export BVPFunction, BVProblem, EnsembleSerial, EnsembleThreads, ODEProblem, ReturnCode,
+    TwoPointBVProblem, init, remake, solve, solve!, successful_retcode
 
 end # module BoundaryValueDiffEqShooting

--- a/lib/BoundaryValueDiffEqShooting/test/qa/qa.jl
+++ b/lib/BoundaryValueDiffEqShooting/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting
 using BoundaryValueDiffEqShooting
 using Test
 
+include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))
+
 run_qa(
     BoundaryValueDiffEqShooting;
     ei_kwargs = (;
@@ -9,4 +11,7 @@ run_qa(
             ignore = (:overloaded_input_type, :pickchunksize),
         ),
     ),
+    reexports_allow = SHOOTING_REEXPORTS,
 )
+
+test_reexport_surface(BoundaryValueDiffEqShooting, SHOOTING_REEXPORTS, @__MODULE__)

--- a/src/BoundaryValueDiffEq.jl
+++ b/src/BoundaryValueDiffEq.jl
@@ -4,7 +4,9 @@ using BoundaryValueDiffEqAscher: BoundaryValueDiffEqAscher, Ascher1, Ascher2, As
     Ascher4, Ascher5, Ascher6, Ascher7
 using BoundaryValueDiffEqCore: BoundaryValueDiffEqCore,
     AbstractBoundaryValueDiffEqAlgorithm, BVPJacobianAlgorithm, BVPVerbosity,
-    DEFAULT_VERBOSE
+    DEFAULT_VERBOSE, DefectControl, GlobalErrorControl, HOErrorControl,
+    HybridErrorControl, NoErrorControl, REErrorControl, SequentialErrorControl,
+    integral
 using BoundaryValueDiffEqFIRK: BoundaryValueDiffEqFIRK, LobattoIIIa2, LobattoIIIa3,
     LobattoIIIa4, LobattoIIIa5, LobattoIIIb2, LobattoIIIb3, LobattoIIIb4, LobattoIIIb5,
     LobattoIIIc2, LobattoIIIc3, LobattoIIIc4, LobattoIIIc5, RadauIIa1, RadauIIa2,
@@ -18,10 +20,18 @@ using OrdinaryDiffEqTsit5: Tsit5
 using Reexport: @reexport
 using SciMLBase: SciMLBase, BVProblem
 
+# The AD selectors and the SciML common interface that `using BoundaryValueDiffEq` is
+# documented to supply on its own: pick an AD backend (docs/src/basics/autodiff.md),
+# build any of the five BVP forms (docs/src/basics/bvp_problem.md), solve or `init` it,
+# `remake` it for a parameter sweep, drive `MultipleShooting` ensembles
+# (docs/src/basics/solve.md), and inspect the return code. Every name stays owned and
+# documented by ADTypes and SciMLBase; approved via `reexports_allow` in test/qa/qa.jl.
 @reexport using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake,
     AutoPolyesterForwardDiff, AutoSparse
-@reexport using SciMLBase: BVPFunction, BVProblem, DynamicalBVPFunction,
-    SecondOrderBVProblem, TwoPointBVProblem, TwoPointSecondOrderBVProblem, init, solve
+@reexport using SciMLBase: BVPFunction, BVProblem, DynamicalBVPFunction, EnsembleProblem,
+    EnsembleSerial, EnsembleThreads, ODEFunction, ReturnCode, SecondOrderBVProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, init, remake, solve, solve!,
+    successful_retcode
 
 function SciMLBase.__init(prob::BVProblem; kwargs...)
     return SciMLBase.__init(prob, Shooting(Tsit5()); kwargs...)
@@ -51,6 +61,13 @@ export BVPM2, BVPSOL, COLNEW # From ODEInterface.jl
 export BVPJacobianAlgorithm
 
 export BVPVerbosity, DEFAULT_VERBOSE
+
+# Error control adaptivity and the cost-functional helper, owned and documented by
+# BoundaryValueDiffEqCore (docs/src/basics/error_control.md, docs/src/basics/solve.md).
+export DefectControl, GlobalErrorControl, SequentialErrorControl, HybridErrorControl,
+    NoErrorControl
+export HOErrorControl, REErrorControl
+export integral
 
 export maxsol, minsol
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -59,3 +59,5 @@ run_qa(
         ),
     ),
 )
+
+test_reexport_surface(BoundaryValueDiffEq, ROOT_REEXPORTS, @__MODULE__)

--- a/test/qa/reexports.jl
+++ b/test/qa/reexports.jl
@@ -1,82 +1,173 @@
-# Audited intentional facade reexports. Keep these lists fixed: additions require an API review.
-const ROOT_REEXPORTS = Symbol[
-    Symbol("Ascher1"),
-    Symbol("Ascher2"),
-    Symbol("Ascher3"),
-    Symbol("Ascher4"),
-    Symbol("Ascher5"),
-    Symbol("Ascher6"),
-    Symbol("Ascher7"),
-    Symbol("AutoEnzyme"),
-    Symbol("AutoFiniteDiff"),
-    Symbol("AutoForwardDiff"),
-    Symbol("AutoMooncake"),
-    Symbol("AutoPolyesterForwardDiff"),
-    Symbol("AutoSparse"),
-    Symbol("BVPFunction"),
-    Symbol("BVPJacobianAlgorithm"),
-    Symbol("BVPVerbosity"),
-    Symbol("BVProblem"),
-    Symbol("DEFAULT_VERBOSE"),
-    Symbol("DynamicalBVPFunction"),
-    Symbol("LobattoIIIa2"),
-    Symbol("LobattoIIIa3"),
-    Symbol("LobattoIIIa4"),
-    Symbol("LobattoIIIa5"),
-    Symbol("LobattoIIIb2"),
-    Symbol("LobattoIIIb3"),
-    Symbol("LobattoIIIb4"),
-    Symbol("LobattoIIIb5"),
-    Symbol("LobattoIIIc2"),
-    Symbol("LobattoIIIc3"),
-    Symbol("LobattoIIIc4"),
-    Symbol("LobattoIIIc5"),
-    Symbol("MIRK2"),
-    Symbol("MIRK3"),
-    Symbol("MIRK4"),
-    Symbol("MIRK5"),
-    Symbol("MIRK6"),
-    Symbol("MIRKN4"),
-    Symbol("MIRKN6"),
-    Symbol("MultipleShooting"),
-    Symbol("RadauIIa1"),
-    Symbol("RadauIIa2"),
-    Symbol("RadauIIa3"),
-    Symbol("RadauIIa5"),
-    Symbol("RadauIIa7"),
-    Symbol("SecondOrderBVProblem"),
-    Symbol("Shooting"),
-    Symbol("TwoPointBVProblem"),
-    Symbol("TwoPointSecondOrderBVProblem"),
-    Symbol("init"),
-    Symbol("maxsol"),
-    Symbol("minsol"),
-    Symbol("solve"),
-]
-const CORE_REEXPORTS = Symbol[
-    Symbol("BVPFunction"),
-    Symbol("BVProblem"),
-    Symbol("DynamicalBVPFunction"),
-    Symbol("GaussNewton"),
-    Symbol("LevenbergMarquardt"),
-    Symbol("NonlinearFunction"),
-    Symbol("NonlinearLeastSquaresProblem"),
-    Symbol("NonlinearProblem"),
-    Symbol("NewtonRaphson"),
-    Symbol("OptimizationFunction"),
-    Symbol("OptimizationProblem"),
-    Symbol("ReturnCode"),
-    Symbol("SecondOrderBVProblem"),
-    Symbol("TrustRegion"),
-    Symbol("TwoPointBVProblem"),
-    Symbol("TwoPointSecondOrderBVProblem"),
-    Symbol("init"),
-    Symbol("remake"),
-    Symbol("solve"),
+# Audited intentional facade reexports: the names each package deliberately makes
+# available from `using <Package>` even though another package owns and documents them.
+#
+# Each list is kept in sync with the reexport `export` block in that package's
+# `src/<Package>.jl` and is handed to `run_qa` as `reexports_allow`, so the strict
+# "no unapproved public reexports" check cannot drift from the source. Adding a name
+# here is an API review; removing one is a breaking change for downstream users who
+# get that name from `using <Package>`.
+
+# ADTypes selectors documented in docs/src/basics/autodiff.md.
+const AD_REEXPORTS = Symbol[
+    :AutoEnzyme,
+    :AutoFiniteDiff,
+    :AutoForwardDiff,
+    :AutoMooncake,
+    :AutoPolyesterForwardDiff,
+    :AutoSparse,
 ]
 
-const FIRK_REEXPORTS = Symbol[
-    Symbol("BVProblem"),
-    Symbol("TwoPointBVProblem"),
-    Symbol("solve"),
+# BoundaryValueDiffEqCore configuration documented in docs/src/basics/autodiff.md and
+# docs/src/basics/verbosity.md.
+const CORE_CONFIG_REEXPORTS = Symbol[
+    :BVPJacobianAlgorithm,
+    :BVPVerbosity,
+    :DEFAULT_VERBOSE,
 ]
+
+# Error control adaptivity documented in docs/src/basics/error_control.md, plus the
+# cost-functional helper documented in docs/src/basics/solve.md.
+const ERROR_CONTROL_REEXPORTS = Symbol[
+    :DefectControl,
+    :GlobalErrorControl,
+    :HOErrorControl,
+    :HybridErrorControl,
+    :NoErrorControl,
+    :REErrorControl,
+    :SequentialErrorControl,
+]
+
+# NonlinearSolveFirstOrder algorithms accepted by every solver's `nlsolve` keyword.
+const NLSOLVE_REEXPORTS = Symbol[
+    :GaussNewton,
+    :LevenbergMarquardt,
+    :NewtonRaphson,
+    :TrustRegion,
+]
+
+const ROOT_REEXPORTS = Symbol[
+    # Solver algorithms owned by the sublibraries.
+    :Ascher1, :Ascher2, :Ascher3, :Ascher4, :Ascher5, :Ascher6, :Ascher7,
+    :LobattoIIIa2, :LobattoIIIa3, :LobattoIIIa4, :LobattoIIIa5,
+    :LobattoIIIb2, :LobattoIIIb3, :LobattoIIIb4, :LobattoIIIb5,
+    :LobattoIIIc2, :LobattoIIIc3, :LobattoIIIc4, :LobattoIIIc5,
+    :MIRK2, :MIRK3, :MIRK4, :MIRK5, :MIRK6,
+    :MIRKN4, :MIRKN6,
+    :MultipleShooting, :Shooting,
+    :RadauIIa1, :RadauIIa2, :RadauIIa3, :RadauIIa5, :RadauIIa7,
+    :maxsol, :minsol,
+    # ADTypes selectors and BoundaryValueDiffEqCore configuration.
+    AD_REEXPORTS...,
+    CORE_CONFIG_REEXPORTS...,
+    ERROR_CONTROL_REEXPORTS...,
+    :integral,
+    # SciML common interface for boundary value problems.
+    :BVPFunction, :BVProblem, :DynamicalBVPFunction, :EnsembleProblem, :EnsembleSerial,
+    :EnsembleThreads, :ODEFunction, :ReturnCode, :SecondOrderBVProblem, :TwoPointBVProblem,
+    :TwoPointSecondOrderBVProblem, :init, :remake, :solve, :solve!, :successful_retcode,
+]
+
+const CORE_REEXPORTS = Symbol[
+    NLSOLVE_REEXPORTS...,
+    :BVPFunction,
+    :BVProblem,
+    :DynamicalBVPFunction,
+    :NonlinearFunction,
+    :NonlinearLeastSquaresProblem,
+    :NonlinearProblem,
+    :OptimizationFunction,
+    :OptimizationProblem,
+    :ReturnCode,
+    :SecondOrderBVProblem,
+    :TwoPointBVProblem,
+    :TwoPointSecondOrderBVProblem,
+    :init,
+    :remake,
+    :solve,
+    :successful_retcode,
+]
+
+# MIRK, FIRK and Ascher share the first-order BVP facade: the problem and function
+# types they solve, the solve/init interface, error control, AD selectors and the
+# inner nonlinear solvers.
+const COLLOCATION_REEXPORTS = Symbol[
+    AD_REEXPORTS...,
+    CORE_CONFIG_REEXPORTS...,
+    ERROR_CONTROL_REEXPORTS...,
+    NLSOLVE_REEXPORTS...,
+    :integral,
+    :BVPFunction,
+    :BVProblem,
+    :ReturnCode,
+    :TwoPointBVProblem,
+    :init,
+    :remake,
+    :solve,
+    :solve!,
+    :successful_retcode,
+]
+
+# MIRK and FIRK additionally document ensembles and `ODEFunction`-wrapped dynamics.
+const MIRK_REEXPORTS = Symbol[COLLOCATION_REEXPORTS..., :EnsembleProblem, :ODEFunction]
+const FIRK_REEXPORTS = MIRK_REEXPORTS
+
+const ASCHER_REEXPORTS = COLLOCATION_REEXPORTS
+
+# MIRKN solves second order BVPs; it has no defect control adaptivity
+# (docs/src/solvers/mirkn.md), so only `NoErrorControl` applies.
+const MIRKN_REEXPORTS = Symbol[
+    AD_REEXPORTS...,
+    CORE_CONFIG_REEXPORTS...,
+    NLSOLVE_REEXPORTS...,
+    :NoErrorControl,
+    :integral,
+    :DynamicalBVPFunction,
+    :ReturnCode,
+    :SecondOrderBVProblem,
+    :TwoPointSecondOrderBVProblem,
+    :init,
+    :remake,
+    :solve,
+    :solve!,
+    :successful_retcode,
+]
+
+# Shooting reduces the BVP to IVPs, so it exposes `ODEProblem` and the ensemble
+# algorithms accepted by `MultipleShooting`'s `ensemblealg` keyword
+# (docs/src/basics/solve.md). It is not a collocation method and takes no `controller`.
+const SHOOTING_REEXPORTS = Symbol[
+    AD_REEXPORTS...,
+    CORE_CONFIG_REEXPORTS...,
+    NLSOLVE_REEXPORTS...,
+    :integral,
+    :BVPFunction,
+    :BVProblem,
+    :EnsembleSerial,
+    :EnsembleThreads,
+    :ODEProblem,
+    :ReturnCode,
+    :TwoPointBVProblem,
+    :init,
+    :remake,
+    :solve,
+    :solve!,
+    :successful_retcode,
+]
+
+"""
+    test_reexport_surface(pkg, reexports, scope)
+
+Assert that every approved reexport is actually reachable from `using pkg`, so an
+allow-list above cannot drift into approving names the package no longer provides.
+`scope` is the module whose own `using pkg` has to bring the name into scope, which
+tests the property downstream users depend on directly.
+"""
+function test_reexport_surface(pkg::Module, reexports, scope::Module)
+    @testset "Reexport surface" begin
+        @testset "$name" for name in reexports
+            @test name in names(pkg)
+            @test isdefined(scope, name)
+        end
+    end
+    return nothing
+end


### PR DESCRIPTION
## What was stripped

Nine commits between 2026-07-29 and 2026-08-16 removed the blanket reexports from every package in this repo:

| commit | package | line removed |
|---|---|---|
| `7a78df3` | MIRK | `@reexport using ADTypes, BoundaryValueDiffEqCore, SciMLBase` (also `export BVPJacobianAlgorithm`, `export integral`) |
| `03b0031` | MIRKN | `@reexport using ADTypes, BoundaryValueDiffEqCore, SciMLBase` |
| `1432eb6` | Ascher | `@reexport using ADTypes, BoundaryValueDiffEqCore, SciMLBase` |
| `7a1da23` | Shooting | `@reexport using ADTypes, BoundaryValueDiffEqCore, SciMLBase` |
| `6414a31` | Shooting | removed the restoration added by `d29391ee` |
| `415662d` | FIRK | `@reexport using ADTypes, BoundaryValueDiffEqCore, SciMLBase` (left only `BVProblem`, `TwoPointBVProblem`, `solve`) |
| `e45ec19`, `a220b68`, `7b48ffe5` | Core | `@reexport using NonlinearSolveFirstOrder, SciMLBase` → explicit list |
| `6ec8df1` | root facade | `@reexport using ADTypes, SciMLBase` → 14 names |

Deleting a reexport silently removes names from what `using <Package>` puts in scope. Nothing inside this repo depended on them — the *same commits* added the explicit imports to the test files instead — so CI stayed green while downstream code broke.

## What this PR does

Follows SciML/Sundials.jl#553, and specifically the shape `a220b68` / `7b48ffe5` **already established for `BoundaryValueDiffEqCore`** (an explicit `@reexport using SciMLBase: <list>` plus a `reexports_allow` allow-list): the blanket reexports stay gone, and each package declares an explicit list of exactly the names its documented workflow needs. This is the same style extended to the five solver sublibraries and the root facade, not a second competing one.

`d29391ee` ("Restore the Shooting public surface as an explicit export list") had already tried this once and re-exported **all 274 names** of the old blanket surface one by one; `6414a31` reverted it. That history is why this PR takes the middle position — *documented use, not whole dependencies* — so Shooting comes back with **26** names, not 274.

## Evidence used to pick the names

1. **`docs/src/**`.** `docs/src/tutorials/optimal_control.md` presents `using BoundaryValueDiffEqMIRK, OptimizationIpopt` as the copy-and-paste block and then calls `integral(...)`, `BVPFunction`, `BVProblem`, `solve` — `integral` had been reachable only through MIRK's `export integral`, which `7a78df3` deleted. `docs/src/tutorials/getting_started.md` uses `using BoundaryValueDiffEqAscher` + `BVPFunction`/`BVProblem` and `using BoundaryValueDiffEqMIRKN` + `SecondOrderBVProblem`. `docs/src/basics/error_control.md` documents `solve(prob, MIRK4(), controller = GlobalErrorControl())`. `docs/src/basics/autodiff.md` documents the six `Auto*` backends and `BVPJacobianAlgorithm`. `docs/src/basics/verbosity.md` documents `BVPVerbosity`/`DEFAULT_VERBOSE`. `docs/src/basics/solve.md` documents `integral` and `ensemblealg = EnsembleThreads()` for `MultipleShooting`.
2. **The explicit imports the stripping commits had to add to the tests** — `using SciMLBase: BVPFunction, BVProblem, ODEFunction, TwoPointBVProblem, EnsembleProblem, ODEProblem, init, remake, solve`, `using ADTypes: AutoEnzyme, AutoFiniteDiff, AutoForwardDiff, AutoMooncake, AutoSparse`, `using NonlinearSolveFirstOrder: GaussNewton, LevenbergMarquardt, NewtonRaphson, TrustRegion`, `using BoundaryValueDiffEqCore: BVPJacobianAlgorithm, DefectControl, GlobalErrorControl, HybridErrorControl, SequentialErrorControl`. Those additions are a direct record of what the reexport used to supply.
3. **`1525e6e7` "test: import SciMLBase directly"**, which had to add `using SciMLBase` to seven root test files that call `successful_retcode` unqualified — `successful_retcode` had come from the root's `@reexport using SciMLBase` until `6ec8df1`.

Deliberately **excluded**: solution types, the integrator interface (`step!`, `reinit!`, `u_modified!`, tstop/saveat handling), callbacks, `EnsembleAnalysis`, and problem/function types for equation classes these solvers cannot handle. `pickchunksize` (a ForwardDiff internal that leaked through the blanket reexport) stays out.

## The restored lists

Shared groups: **AD** = `AutoEnzyme`, `AutoFiniteDiff`, `AutoForwardDiff`, `AutoMooncake`, `AutoPolyesterForwardDiff`, `AutoSparse` (ADTypes). **Config** = `BVPJacobianAlgorithm`, `BVPVerbosity`, `DEFAULT_VERBOSE` (Core). **Error control** = `DefectControl`, `GlobalErrorControl`, `SequentialErrorControl`, `HybridErrorControl`, `NoErrorControl`, `HOErrorControl`, `REErrorControl` (Core). **nlsolve** = `GaussNewton`, `LevenbergMarquardt`, `NewtonRaphson`, `TrustRegion` (NonlinearSolveFirstOrder).

| package | foreign exports | added |
|---|---|---|
| **BoundaryValueDiffEq** (root) | 68 | `EnsembleProblem`, `EnsembleSerial`, `EnsembleThreads`, `ODEFunction`, `ReturnCode`, `remake`, `solve!`, `successful_retcode` (SciMLBase); error control group + `integral` (Core) |
| **BoundaryValueDiffEqCore** | 20 | `successful_retcode` |
| **BoundaryValueDiffEqMIRK** | 32 | AD + Config + Error control + nlsolve + `integral`; `BVPFunction`, `BVProblem`, `TwoPointBVProblem`, `EnsembleProblem`, `ODEFunction`, `ReturnCode`, `init`, `remake`, `solve`, `solve!`, `successful_retcode` |
| **BoundaryValueDiffEqFIRK** | 32 | same as MIRK (it previously kept only `BVProblem`, `TwoPointBVProblem`, `solve`) |
| **BoundaryValueDiffEqAscher** | 30 | same as MIRK minus `EnsembleProblem`/`ODEFunction` (Ascher documents no ensemble workflow) |
| **BoundaryValueDiffEqMIRKN** | 24 | AD + Config + nlsolve + `NoErrorControl` + `integral`; `SecondOrderBVProblem`, `TwoPointSecondOrderBVProblem`, `DynamicalBVPFunction`, `ReturnCode`, `init`, `remake`, `solve`, `solve!`, `successful_retcode`. Second order only, and no defect control adaptivity per `docs/src/solvers/mirkn.md`, so only `NoErrorControl` |
| **BoundaryValueDiffEqShooting** | 26 | AD + Config + nlsolve + `integral`; `BVPFunction`, `BVProblem`, `TwoPointBVProblem`, `ODEProblem`, `EnsembleSerial`, `EnsembleThreads`, `ReturnCode`, `init`, `remake`, `solve`, `solve!`, `successful_retcode`. Not a collocation method and takes no `controller`, so no error control types |

## Documentation

New rendered page `docs/src/api/reexports.md` (wired into `docs/pages.jl` under **API**), grouped by role, naming and linking the owning package for every group — SciMLBase, ADTypes, NonlinearSolveFirstOrder, BoundaryValueDiffEqCore — and closing with an explicit boundary statement ("anything else from SciMLBase must be imported from SciMLBase directly", plus what was deliberately left out and why). `a220b68` made Core's reexports explicit in source but added no docs, so there was no existing page to conflict with.

The docs workarounds the strip forced are reverted so the executed examples exercise the restored surface: the two `@example` blocks in `optimal_control.md` go back to `using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots` (matching the copy-and-paste block above them), and the `shooting.md` jldoctest goes back to `using BoundaryValueDiffEqShooting`.

Each list now lives in three places kept in sync: the `export` block in `src/<Package>.jl`, the allow-list in `test/qa/reexports.jl` passed to `run_qa` as `reexports_allow`, and the docs page. A new `test_reexport_surface` helper asserts every approved name is both in `names(pkg)` and actually in scope from `using pkg`, so the allow-list cannot drift.

## Why this is not breaking

It only adds bindings back to the public surface; nothing is removed or renamed. Code that already imports these names explicitly is unaffected.

## What was verified

Run locally on this machine (Julia 1.11.8, a dev environment with all six sublibraries plus the root package `Pkg.develop`ed):

- All seven packages precompile.
- `SciMLTesting.public_reexports(pkg; allow = <LIST>)` — the exact predicate behind `run_qa`'s "No unapproved public reexports" check, on SciMLTesting **v2.11.0** — is empty for all seven, and `test_reexport_surface` passes for all seven: **471 tests, 0 failures**. This confirms each allow-list is neither too small (nothing unapproved) nor stale (every entry really is exported and really is in scope from `using pkg`).
- `run_qa(pkg; jet = false, aqua = false, api_docs = false, ei_kwargs = <the repo's own>)` — i.e. all six ExplicitImports checks plus the reexport check — passes for Core, MIRK, FIRK, MIRKN, Ascher, Shooting and the root facade (7/7 each). This was the main risk: the new `using X: ...` lines could have tripped the stale-import or public-import checks. They do not.
- End-to-end smoke tests solving a real BVP with **only** `using <Package>` in scope: root facade (README pendulum + `GlobalErrorControl` + `BVPJacobianAlgorithm(AutoFiniteDiff)` + `remake`), MIRK (`BVPFunction`, `NewtonRaphson`, `DefectControl`, `ReturnCode`, `integral`), FIRK (`RadauIIa5`), MIRKN (`SecondOrderBVProblem`), Ascher (BVDAE via `BVPFunction` mass matrix), Shooting (`Shooting`, `MultipleShooting` with `ensemblealg = EnsembleSerial()`, `BVPJacobianAlgorithm`). All pass.
- Runic reports every changed `.jl` file already formatted.

**Not** run locally: the full `Pkg.test()` suites and the docs build. This machine is heavily loaded (load average ~50 on 12 cores) and the docs build pulls Plots, OptimizationIpopt and ODEInterface. CI covers both.

## Downstream `BoundaryValueDiffEq.jl/All` failures elsewhere in SciML

Checked and they are **not** caused by the stripped surface. The failing lanes in SciML/SciMLBase.jl (run 32635237370) and SciML/NonlinearSolve.jl (run 32635303526) both fail in `test/misc/bigfloat_test.jl` with the same error:

```
MethodError: promote_rule(::Type{BigFloat}, ::Type{SparseConnectivityTracer.Dual{BigFloat, ...}}) is ambiguous.
  promote_rule(::Type{BigFloat}, ::Type{<:Real})                          @ Base.MPFR
  promote_rule(::Type{N}, ::Type{Dual{P,T}}) where {P,T,N<:Real}          @ SparseConnectivityTracer
```

which comes from `PreallocationTools.get_tmp` on a `DiffCache{Vector{BigFloat}}` under a SparseConnectivityTracer tracer — an unrelated `promote_rule` ambiguity between Base's `BigFloat` rule and SparseConnectivityTracer's `Dual` rule. No `UndefVarError` appears in either log. That needs a separate fix in SparseConnectivityTracer or PreallocationTools.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
