### PR TITLE
Release 6 sub-libraries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEq"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "5.24.0"
+version = "5.25.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -35,12 +35,12 @@ BoundaryValueDiffEqODEInterfaceExt = "ODEInterface"
 
 [compat]
 ADTypes = "1.14"
-BoundaryValueDiffEqAscher = "1.15.2"
-BoundaryValueDiffEqCore = "2.7.3"
-BoundaryValueDiffEqFIRK = "1.17.2"
-BoundaryValueDiffEqMIRK = "1.17.2"
-BoundaryValueDiffEqMIRKN = "1.16.2"
-BoundaryValueDiffEqShooting = "1.17.3"
+BoundaryValueDiffEqAscher = "1.16.0"
+BoundaryValueDiffEqCore = "2.8.1"
+BoundaryValueDiffEqFIRK = "1.19.0"
+BoundaryValueDiffEqMIRK = "1.18.0"
+BoundaryValueDiffEqMIRKN = "1.17.0"
+BoundaryValueDiffEqShooting = "1.18.0"
 DiffEqBase = "6.183, 7"
 DiffEqDevTools = "2.48, 3"
 DifferentiationInterface = "0.7.15"

--- a/lib/BoundaryValueDiffEqAscher/Project.toml
+++ b/lib/BoundaryValueDiffEqAscher/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqAscher"
 uuid = "7227322d-7511-4e07-9247-ad6ff830280e"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.15.3"
+version = "1.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -22,7 +22,7 @@ BoundaryValueDiffEqCore = {path = "../BoundaryValueDiffEqCore"}
 SafeTestsets = "0.1.0"
 ADTypes = "1.14"
 AlmostBlockDiagonals = "0.1.10"
-BoundaryValueDiffEqCore = "2.7.3"
+BoundaryValueDiffEqCore = "2.8.1"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44, 3"
 DifferentiationInterface = "0.7.15"

--- a/lib/BoundaryValueDiffEqCore/Project.toml
+++ b/lib/BoundaryValueDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundaryValueDiffEqCore"
 uuid = "56b672f2-a5fe-4263-ab2d-da677488eb3a"
-version = "2.8.0"
+version = "2.8.1"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
 
 [deps]

--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.18.0"
+version = "1.19.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -33,7 +33,7 @@ SafeTestsets = "0.1.0"
 ADTypes = "1.14"
 ArrayInterface = "7.18"
 BandedMatrices = "1.7.5"
-BoundaryValueDiffEqCore = "2.7.3"
+BoundaryValueDiffEqCore = "2.8.1"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44, 3"
 DifferentiationInterface = "0.7.15"

--- a/lib/BoundaryValueDiffEqMIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRK"
 uuid = "1a22d4ce-7765-49ea-b6f2-13c8438986a6"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.5"
+version = "1.18.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -30,7 +30,7 @@ BoundaryValueDiffEqCore = {path = "../BoundaryValueDiffEqCore"}
 ADTypes = "1.14"
 ArrayInterface = "7.18"
 BandedMatrices = "1.7.5"
-BoundaryValueDiffEqCore = "2.7.3"
+BoundaryValueDiffEqCore = "2.8.1"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44, 3"
 DifferentiationInterface = "0.7.15"

--- a/lib/BoundaryValueDiffEqMIRKN/Project.toml
+++ b/lib/BoundaryValueDiffEqMIRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqMIRKN"
 uuid = "9255f1d6-53bf-473e-b6bd-23f1ff009da4"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.16.4"
+version = "1.17.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -23,7 +23,7 @@ BoundaryValueDiffEqCore = {path = "../BoundaryValueDiffEqCore"}
 [compat]
 SafeTestsets = "0.1.0"
 ADTypes = "1.14"
-BoundaryValueDiffEqCore = "2.7.3"
+BoundaryValueDiffEqCore = "2.8.1"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44, 3"
 DifferentiationInterface = "0.7.15"

--- a/lib/BoundaryValueDiffEqShooting/Project.toml
+++ b/lib/BoundaryValueDiffEqShooting/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqShooting"
 uuid = "ed55bfe0-3725-4db6-871e-a1dc9f42a757"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.17.4"
+version = "1.18.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -30,7 +30,7 @@ SafeTestsets = "0.1.0"
 ADTypes = "1.14"
 ArrayInterface = "7.18"
 BandedMatrices = "1.11.0"
-BoundaryValueDiffEqCore = "2.7.3"
+BoundaryValueDiffEqCore = "2.8.1"
 ConcreteStructs = "0.2.3"
 DiffEqDevTools = "2.44, 3"
 DifferentiationInterface = "0.7.15"


### PR DESCRIPTION
Sub-libraries whose registered tree has drifted from `master` are bumped and released together.

- `BoundaryValueDiffEqAscher` 1.15.3 -> 1.16.0 (minor)
- `BoundaryValueDiffEqCore` 2.8.0 -> 2.8.1 (patch)
- `BoundaryValueDiffEqFIRK` 1.18.0 -> 1.19.0 (minor)
- `BoundaryValueDiffEqMIRK` 1.17.5 -> 1.18.0 (minor)
- `BoundaryValueDiffEqMIRKN` 1.16.4 -> 1.17.0 (minor)
- `BoundaryValueDiffEqShooting` 1.17.4 -> 1.18.0 (minor)

- **root `BoundaryValueDiffEq`** 5.24.0 -> 5.25.0

Inter-sub-library `[compat]` lower bounds are raised to the new versions in the same commit, so a resolved set never mixes a new sub-library with an older sibling it was not tested against. All bumps are patch/minor - no exported name is removed anywhere in this set, so nothing here is breaking and no retroactive cap is required.

For `0.x` sub-libraries the patch slot is used, since the minor is the breaking axis under Julia's SemVer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R