### PR TITLE
Avoid sparse AD defaults for BigFloat BVPs

### DIFF
--- a/lib/BoundaryValueDiffEqCore/src/types.jl
+++ b/lib/BoundaryValueDiffEqCore/src/types.jl
@@ -140,12 +140,14 @@ end
     AutoFiniteDiff(), sparsity_detector = TracerLocalSparsityDetector(),
     coloring_algorithm = GreedyColoringAlgorithm()
 )
+@inline __sparse_tracer_compatible(::Type{BigFloat}) = false
+@inline __sparse_tracer_compatible(::Type{T}) where {T} = true
 @inline function __default_sparse_ad(::Type{T}) where {T}
-    return AutoSparse(
-        ifelse(ForwardDiff.can_dual(T), AutoForwardDiff(), AutoFiniteDiff()),
-        sparsity_detector = TracerLocalSparsityDetector(),
-        coloring_algorithm = GreedyColoringAlgorithm()
-    )
+    return __sparse_tracer_compatible(T) ? AutoSparse(
+            ifelse(ForwardDiff.can_dual(T), AutoForwardDiff(), AutoFiniteDiff()),
+            sparsity_detector = TracerLocalSparsityDetector(),
+            coloring_algorithm = GreedyColoringAlgorithm()
+        ) : __default_nonsparse_ad(T)
 end
 
 @inline function __default_bc_sparse_ad(x::AbstractArray{T}) where {T}
@@ -157,11 +159,11 @@ end
     coloring_algorithm = GreedyColoringAlgorithm()
 )
 @inline function __default_bc_sparse_ad(::Type{T}) where {T}
-    return AutoSparse(
-        ifelse(ForwardDiff.can_dual(T), AutoForwardDiff(), AutoFiniteDiff()),
-        sparsity_detector = TracerLocalSparsityDetector(),
-        coloring_algorithm = GreedyColoringAlgorithm()
-    )
+    return __sparse_tracer_compatible(T) ? AutoSparse(
+            ifelse(ForwardDiff.can_dual(T), AutoForwardDiff(), AutoFiniteDiff()),
+            sparsity_detector = TracerLocalSparsityDetector(),
+            coloring_algorithm = GreedyColoringAlgorithm()
+        ) : __default_nonsparse_ad(T)
 end
 
 """

--- a/lib/BoundaryValueDiffEqCore/test/Core/util_tests.jl
+++ b/lib/BoundaryValueDiffEqCore/test/Core/util_tests.jl
@@ -87,6 +87,16 @@ end
     @test all(iszero, uc2[3:end])
 end
 
+@testset "__default_sparse_ad BigFloat uses dense AD" begin
+    using ADTypes: AutoForwardDiff, AutoSparse
+    using BoundaryValueDiffEqCore: __default_bc_sparse_ad, __default_sparse_ad
+
+    @test __default_sparse_ad(BigFloat) isa AutoForwardDiff
+    @test __default_bc_sparse_ad(BigFloat) isa AutoForwardDiff
+    @test __default_sparse_ad(Float64) isa AutoSparse
+    @test __default_bc_sparse_ad(Float64) isa AutoSparse
+end
+
 @testset "_process_verbose_param foreign AbstractVerbositySpecifier" begin
     # DiffEqBase.DEVerbosity is a foreign AbstractVerbositySpecifier that
     # can flow in via DiffEqBase's `solve`/`init` default `verbose` kwarg.


### PR DESCRIPTION
## What changed and why

Select dense ForwardDiff by default for `BigFloat` state and boundary-condition Jacobians, while preserving the existing sparse default for compatible element types. `PreallocationTools` 1.5.0 removed its SparseConnectivityTracer-specific cache path; the resulting generic promotion between `BigFloat` and `SparseConnectivityTracer.Dual` is ambiguous and breaks the default sparse BigFloat solve.

Explicitly requested sparse AD remains available. This only changes the package's default choice for `BigFloat`.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

On unmodified `master`:

```text
GROUP=Misc julia +release --project -e 'using Pkg; Pkg.test()'
MethodError: promote_rule(::Type{BigFloat}, ::Type{SparseConnectivityTracer.Dual{...}}) is ambiguous
  at test/misc/bigfloat_test.jl:24
```

The dependency boundary was reproduced independently with a standalone `PreallocationTools.get_tmp` call using SparseConnectivityTracer 1.2.2:

- PreallocationTools 1.4.1: succeeds
- PreallocationTools 1.5.0: produces the same ambiguous `promote_rule`
- PreallocationTools 1.6.x/current: still takes the failing generic path

## Passing after

- `GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'`
  - `Utility Tests | 24 pass / 24 total`
  - Covers both the state-Jacobian and boundary-condition default selectors for `BigFloat` and verifies that `Float64` remains sparse.
- `GROUP=Misc julia +release --project -e 'using Pkg; Pkg.test()'`
  - `BigFloat Tests | 7 pass / 7 total`
  - `Verbose Tests | 78 pass / 78 total`
  - `Public API Package Splits | 12 pass / 12 total`
  - `Manifolds Tests | 11 pass / 11 total`
  - Final result: `Testing BoundaryValueDiffEq tests passed`
- `GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'`
  - `Quality Assurance | 157 pass / 157 total`
- `julia +release -m Runic --check lib/BoundaryValueDiffEqCore/src/types.jl lib/BoundaryValueDiffEqCore/test/Core/util_tests.jl`
  - exited successfully
- `typos lib/BoundaryValueDiffEqCore/src/types.jl lib/BoundaryValueDiffEqCore/test/Core/util_tests.jl`
  - exited successfully
- `git diff --check`
  - exited successfully

## CI failure classification

The PR's root `Misc`, `QA`, and wrapper groups pass. Every audited red job outside the changed BigFloat default-selection path also reproduces on clean `master` and has been kept separate:

- FIRK and Ascher exact-public-name expectations were stale after documented reexports were restored. Test-only draft https://github.com/SciML/BoundaryValueDiffEq.jl/pull/614 updates those expected sets.
- FIRK `NESTED_NLLS_UNDERCONSTRAINED` differentiated through a singular underconstrained inner stage solve. Focused draft https://github.com/SciML/BoundaryValueDiffEq.jl/pull/615 passes the public Radau discriminator, the full group 22/22, and FIRK QA 84/84.
- FIRK AD signal 11 occurs in an Enzyme-differentiated `Float64` residual comprehension. Refreshed draft https://github.com/SciML/BoundaryValueDiffEq.jl/pull/547 passes AD 9/9 both normally and under exact CI coverage/check-bounds flags, plus FIRK QA 84/84. A standalone no-SciML Enzyme reduction ran 100 iterations without crashing, so no unsupported upstream issue was filed.
- ModelingToolkit InterfaceII doubled jump callback effects because JumpProcesses merged a symbolic callback twice. Draft https://github.com/SciML/JumpProcesses.jl/pull/642 passes its 2/2 public-API regression and full local MTK InterfaceII.
- The earlier FIRK `EXPANDED_BASIC` result ended when a self-hosted runner lost communication; clean local `master` passes 126/126.

## Not verified locally

- `GROUP=Everything` and GPU-specific groups were not run.
- Documentation was not rebuilt because this changes no public name, docstring, or rendered documentation.

## Related evidence

- Current master BigFloat failure: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/32955500376/job/98180952222
- First CI failure at the dependency boundary: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/31819480479/job/94840785297
- Last passing CI comparison: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/31497419809/job/93805990958
- PreallocationTools change: https://github.com/SciML/PreallocationTools.jl/pull/198
- Public-facade follow-up: https://github.com/SciML/BoundaryValueDiffEq.jl/pull/614
- Nested underconstrained follow-up: https://github.com/SciML/BoundaryValueDiffEq.jl/pull/615
- FIRK AD follow-up: https://github.com/SciML/BoundaryValueDiffEq.jl/pull/547
- MTK downstream follow-up: https://github.com/SciML/JumpProcesses.jl/pull/642

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f).
