### PR TITLE
Fix underconstrained nested FIRK stage AD

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
+++ b/lib/BoundaryValueDiffEqFIRK/src/collocation.jl
@@ -12,6 +12,11 @@ function Φ!(residual, cache::FIRKCacheNested, y, u, trait, constraint)
     )
 end
 
+@inline function __nested_stage_parameter(cache::FIRKCacheNested, p)
+    length(cache.bcresid_prototype) < cache.M && return nodual_value(p)
+    return p
+end
+
 @views function Φ!(
         residual, fᵢ_cache, k_discrete, f!, TU::FIRKTableau{false}, y, u, p,
         mesh, mesh_dt, stage::Int, f_prototype, singular_term, ::DiffCacheNeeded, ::Val{true}
@@ -195,7 +200,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ
@@ -227,7 +232,7 @@ end
 
         K = get_tmp(k_discrete[i], u)
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
         @. K = nestsol.u
         @. residᵢ = yᵢ₊₁ - yᵢ
@@ -385,7 +390,7 @@ end
         nestprob_p[2] = T(mesh_dt[i])
         nestprob_p[3:end] = yᵢ
 
-        _nestprob = remake(nest_prob, p = nestprob_p)
+        _nestprob = remake(nest_prob, p = __nested_stage_parameter(cache, nestprob_p))
         nestsol = __solve(_nestprob, nest_nlsolve_alg; alg.nested_nlsolve_kwargs...)
 
         @. residᵢ = yᵢ₊₁ - yᵢ


### PR DESCRIPTION
## What changed

Underconstrained nested FIRK stage systems now remove outer ForwardDiff dual values from their nonlinear-problem parameters before solving the inner system. The inner system is singular by construction when the boundary residual has fewer equations than FIRK stages, so differentiating it through an ordinary nonlinear-solve inverse raises a `SingularException`.

The guard is limited to `length(cache.bcresid_prototype) < cache.M`; square nested systems retain the existing differentiable path. This supersedes only the nested-solve portion of https://github.com/SciML/BoundaryValueDiffEq.jl/pull/552.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

On clean `master` at `7fb26ea45d35d0ba0cf4b108b6429e7267ec35c8`, a public RadauIIa5 nested solve failed in `nonlinearsolve_forwarddiff_solve` with:

```text
ERROR: LinearAlgebra.SingularException(90)
```

Clean-base CI reports four equivalent LobattoIIIa4 Newton/Gauss-Newton singular solves:
https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33100708886/job/98621904890

## Passing after

```text
same public solve: ReturnCode.Success
FIRK Nested Underconstrained NLLS Tests | 22 pass | 22 total | 5m50.2s
Quality Assurance                       | 84 pass | 84 total | 1m39.3s
```

Fresh CI passes the complete regression group on all tested Julia versions:

- Julia 1: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386051
- Julia LTS: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702385851
- Julia prerelease: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702385978

Runic, spelling, `git diff --check`, root QA, FIRK QA, docs, benchmarks, and all other completed nested groups pass.

## Fresh CI red-check classification

No red check is introduced by this three-call-site nested-solve change.

- Ascher and FIRK downgrade failures are the clean-base exact-export assertions fixed separately by https://github.com/SciML/BoundaryValueDiffEq.jl/pull/614: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016528/job/98701977609 and https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016528/job/98701977582
- All three FIRK `PUBLIC_FACADE` failures are the same clean-base assertion, also fixed by https://github.com/SciML/BoundaryValueDiffEq.jl/pull/614: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386175, https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386185, and https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386169
- ModelingToolkit InterfaceII has the same SDE `nlsolve!` cache error across all three unrelated drafts; the owning-package follow-up is https://github.com/SciML/JumpProcesses.jl/pull/642: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016541/job/98690938207
- AD prerelease fails inside Mooncake while compiling `uppercase(::Char)` with `unexpected expr (:utf8proc_toupper,)`; Julia 1 AD passes, so this is a prerelease/compiler dependency failure: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386136
- Both `EXPANDED_BASIC` failures are runner infrastructure; GitHub reports “self-hosted runner lost communication”: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702386200 and https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33122016688/job/98702385961

Documentation was built successfully in CI. GPU paths were not exercised.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f).
