### PR TITLE
Format (and minor re-organize) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ function simplependulum!(du, u, p, t)
     dθ = u[2]
     du[1] = dθ
     du[2] = -9.81 * sin(θ)
+    return
 end
 function bc!(residual, u, p, t)
     residual[1] = u(pi / 4)[1] + pi / 2
     residual[2] = u(pi / 2)[1] - pi / 2
+    return
 end
 prob = BVProblem(simplependulum!, bc!, [pi / 2, pi / 2], tspan)
 sol = solve(prob, MIRK4(), dt = 0.05)

--- a/docs/src/basics/error_control.md
+++ b/docs/src/basics/error_control.md
@@ -13,9 +13,12 @@ sol = solve(prob, MIRK4(), dt = 0.01, adaptive = true)
 Actually, BoundaryValueDiffEq.jl supports both defect and global error control adaptivity(while the defect control is the default controller) [boisvert2013runge](@Citet), to specify different error control methods, we simply need to specify the `controller` keyword in `solve`:
 
 ```julia
-sol = solve(prob, MIRK4(), dt = 0.01, controller = GlobalErrorControl()) # Use global error control
-sol = solve(prob, MIRK4(), dt = 0.01, controller = SequentialErrorControl()) # Use Sequential error control
-sol = solve(prob, MIRK4(), dt = 0.01, controller = HybridErrorControl()) # Use Hybrid error control
+# Use global error control
+sol = solve(prob, MIRK4(), dt = 0.01, controller = GlobalErrorControl())
+# Use Sequential error control
+sol = solve(prob, MIRK4(), dt = 0.01, controller = SequentialErrorControl())
+# Use Hybrid error control
+sol = solve(prob, MIRK4(), dt = 0.01, controller = HybridErrorControl())
 ```
 
 ## Error control methods

--- a/docs/src/basics/verbosity.md
+++ b/docs/src/basics/verbosity.md
@@ -15,11 +15,13 @@ using BoundaryValueDiffEq
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = -u[1]
+    return
 end
 
 function bc!(res, u, p, t)
     res[1] = u[1][1]
     res[2] = u[end][1] - 1
+    return
 end
 
 u0 = [0.0, 1.0]
@@ -28,7 +30,7 @@ prob = BVProblem(f!, bc!, u0, tspan)
 
 # Solve with detailed verbosity to see convergence info
 verbose = BVPVerbosity(Detailed())
-sol = solve(prob, MIRK4(), dt = 0.1, verbose = verbose)
+sol = solve(prob, MIRK4(), dt = 0.1; verbose)
 
 # Solve with completely silent output (no warnings or deprecations)
 sol = solve(prob, MIRK4(), dt = 0.1, verbose = BVPVerbosity(None()))
@@ -43,27 +45,19 @@ BoundaryValueDiffEq.jl solvers internally use NonlinearSolve.jl (for nonlinear s
 
 ```julia
 # Silence BVP messages but show all NonlinearSolve convergence info
-verbose = BVPVerbosity(
-    None(),
-    nonlinear_verbosity = All()
-)
-sol = solve(prob, MIRK4(), dt = 0.1, verbose = verbose)
+verbose = BVPVerbosity(None(), nonlinear_verbosity = All())
+sol = solve(prob, MIRK4(); dt = 0.1, verbose)
 
 # Show standard BVP messages but silence NonlinearSolve output
-verbose = BVPVerbosity(
-    Standard(),
-    nonlinear_verbosity = None()
-)
-sol = solve(prob, MIRK4(), dt = 0.1, verbose = verbose)
+verbose = BVPVerbosity(Standard(), nonlinear_verbosity = None())
+sol = solve(prob, MIRK4(); dt = 0.1, verbose)
 
 # Control Optimization.jl verbosity when using optimization-based methods
-using Optimization, OptimizationOptimJL
+using Optimization
+using OptimizationOptimJL: BFGS
 
-verbose = BVPVerbosity(
-    Standard(),
-    optimization_verbosity = Detailed()
-)
-sol = solve(prob, MIRK4(optimize = OptimizationOptimJL.BFGS()), dt = 0.1, verbose = verbose)
+verbose = BVPVerbosity(Standard(), optimization_verbosity = Detailed())
+sol = solve(prob, MIRK4(; optimize = BFGS()), dt = 0.1, verbose)
 ```
 
 ## API Reference

--- a/docs/src/solvers/firk.md
+++ b/docs/src/solvers/firk.md
@@ -16,34 +16,39 @@ using BoundaryValueDiffEqFIRK
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = 0
+    return
 end
 
 function bc!(residual, u, p, t)
     residual[1] = u(0.0)[1] - 1
     residual[2] = u(1.0)[1]
+    return
 end
 
 prob = BVProblem(f!, bc!, [1.0, -1.0], (0.0, 1.0); nlls = Val(false))
-sol = solve(prob, RadauIIa5(); dt = 0.2, abstol = 1e-8)
+sol = solve(prob, RadauIIa5(); dt = 0.2, abstol = 1.0e-8)
 
-@assert isapprox(sol(0.0)[1], 1.0; atol = 1e-6)
-@assert isapprox(sol(1.0)[1], 0.0; atol = 1e-6)
+@assert isapprox(sol(0.0)[1], 1.0; atol = 1.0e-6)
+@assert isapprox(sol(1.0)[1], 0.0; atol = 1.0e-6)
 
 function bca!(residual, u, p)
     residual[1] = u[1] - 1
+    return
 end
 
 function bcb!(residual, u, p)
     residual[1] = u[1]
+    return
 end
 
 two_point_prob = TwoPointBVProblem(
     f!, (bca!, bcb!), [1.0, -1.0], (0.0, 1.0);
-    bcresid_prototype = (zeros(1), zeros(1)), nlls = Val(false))
-two_point_sol = solve(two_point_prob, RadauIIa5(); dt = 0.2, abstol = 1e-8)
+    bcresid_prototype = (zeros(1), zeros(1)), nlls = Val(false)
+)
+two_point_sol = solve(two_point_prob, RadauIIa5(); dt = 0.2, abstol = 1.0e-8)
 
-@assert isapprox(two_point_sol(0.0)[1], 1.0; atol = 1e-6)
-@assert isapprox(two_point_sol(1.0)[1], 0.0; atol = 1e-6)
+@assert isapprox(two_point_sol(0.0)[1], 1.0; atol = 1.0e-6)
+@assert isapprox(two_point_sol(1.0)[1], 0.0; atol = 1.0e-6)
 # output
 ```
 

--- a/docs/src/solvers/shooting.md
+++ b/docs/src/solvers/shooting.md
@@ -18,19 +18,21 @@ using OrdinaryDiffEqTsit5: Tsit5
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = 0
+    return
 end
 
 function bc!(residual, u, p, t)
     residual[1] = u(0.0)[1] - 1
     residual[2] = u(1.0)[1]
+    return
 end
 
 prob = BVProblem(f!, bc!, [1.0, -1.0], (0.0, 1.0); nlls = Val(false))
-sol = solve(prob, Shooting(Tsit5()); abstol = 1e-8)
+sol = solve(prob, Shooting(Tsit5()); abstol = 1.0e-8)
 
 @assert sol.retcode == ReturnCode.Success
-@assert isapprox(sol(0.0)[1], 1.0; atol = 1e-6)
-@assert isapprox(sol(1.0)[1], 0.0; atol = 1e-6)
+@assert isapprox(sol(0.0)[1], 1.0; atol = 1.0e-6)
+@assert isapprox(sol(1.0)[1], 0.0; atol = 1.0e-6)
 # output
 ```
 

--- a/docs/src/tutorials/continuation.md
+++ b/docs/src/tutorials/continuation.md
@@ -3,31 +3,33 @@
 Continuation is a commonly used technique for solving numerically difficult boundary value problems, we exploit the priori knowledge of the solution as initial guess to accelerate the BVP solving by breaking up the difficult BVP into a sequence of simpler problems. For example, we use the problem from [ascher1995numerical](@Citet) in this tutorial:
 
 ```math
-ε y'' + xy' = ε \pi^2\cos(\pi x) - \pi x\sin(\pi x)
+ε y'' + xy' = ε π^2 \cos(πx) - πx \sin(πx)
 ```
 
-for ``ε = 10^{-4}``, on ``t\in[-1,1]`` with two point boundary conditions ``y(-1)=-2``, ``y(1)=0``. With analytical solution of ``y(x) = \cos(\pi x) + \operatorname{erf}(x/\sqrt{2ε})/\operatorname{erf}(1/\sqrt{2ε})``, this problem has a rapid transition layer at ``x=0``, making it difficult to solve numerically. In this tutorial, we will showcase how to use continuation with BoundaryValueDiffEq.jl to solve this BVP.
+for ``ε = 10^{-4}``, on ``t\in[-1,1]`` with two point boundary conditions ``y(-1) = -2``, ``y(1) = 0``. With analytical solution of ``y(x) = \cos(πx) + \operatorname{erf}(x/\sqrt{2ε}) / \operatorname{erf}(1/\sqrt{2ε})``, this problem has a rapid transition layer at ``x = 0``, making it difficult to solve numerically. In this tutorial, we will showcase how to use continuation with BoundaryValueDiffEq.jl to solve this BVP.
 
 We use the substitution to transform this problem into a first order BVP system:
 
 ```math
 \begin{align*}
 y_1'&= y_2 \\
-y_2'&= -\frac{x}{ε} y_2 - \pi^2\cos(\pi x) - \frac{\pi x}{ε} \sin(\pi x)
+y_2'&= -\frac{x}{ε} y_2 - π^2 \cos(πx) - \frac{πx}{ε} \sin(πx)
 \end{align*}
 ```
 
-Since this BVP would become difficult to solve when ``0<ε\ll 1``, we start the continuation with relatively bigger ``ε`` to first obtain a good initial guess for cases when $\epsilon$ are becoming extremely small. We can just use the previous solution from BVP solving as the initial guess `u0` when constructing a new `BVProblem`.
+Since this BVP would become difficult to solve when ``0 < ε \ll 1``, we start the continuation with relatively bigger ``ε`` to first obtain a good initial guess for cases when ``ε`` are becoming extremely small. We can just use the previous solution from BVP solving as the initial guess `u0` when constructing a new `BVProblem`.
 
 ```@example continuation
 using BoundaryValueDiffEq, Plots
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = -t / p * u[2] - pi^2 * cospi(t) - pi * t / p * sinpi(t)
+    return
 end
 function bc!(res, u, p, t)
     res[1] = u[1][1] + 2
     res[2] = u[end][1]
+    return
 end
 tspan = (-1.0, 1.0)
 sol = [1.0, 0.0]

--- a/docs/src/tutorials/extremum.md
+++ b/docs/src/tutorials/extremum.md
@@ -5,8 +5,8 @@ In many physical systems, boundary conditions are not always defined at fixed po
 Let's walk through this functionality with an intuitive example. We still revisit the simple pendulum example here, but this time, suppose we need to impose the maximum and minimum value to our boundary conditions, specified as:
 
 ```math
-\max{u}=ub\\
-\min{u}=lb
+\max{u} = ub \\
+\min{u} = lb
 ```
 
 where `lb=-4.8161991710010925` and `ub=5.0496477654230745`. So the states must conform that the maximum value of the state should be `lb` while the minimum value of the state should be `ub`. To solve such problems, we can simply use the `maxsol` and `minsol` functions when defining the boundary value problem in BoundaryValueDiffEq.jl.
@@ -15,14 +15,15 @@ where `lb=-4.8161991710010925` and `ub=5.0496477654230745`. So the states must c
 using BoundaryValueDiffEq
 tspan = (0.0, pi / 2)
 function simplependulum!(du, u, p, t)
-    θ = u[1]
-    dθ = u[2]
+    θ, dθ = u
     du[1] = dθ
     du[2] = -9.81 * sin(θ)
+    return
 end
 function bc!(residual, u, p, t)
     residual[1] = maxsol(u, (0.0, pi / 2)) - 5.0496477654230745
     residual[2] = minsol(u, (0.0, pi / 2)) + 4.8161991710010925
+    return
 end
 prob = BVProblem(simplependulum!, bc!, [pi / 2, pi / 2], tspan)
 ```
@@ -33,7 +34,8 @@ the boundary condition residuals.
 ```julia
 using Plots
 jac_alg = BVPJacobianAlgorithm(;
-    bc_diffmode = AutoFiniteDiff(), nonbc_diffmode = AutoSparse(AutoFiniteDiff())
+    bc_diffmode = AutoFiniteDiff(),
+    nonbc_diffmode = AutoSparse(AutoFiniteDiff())
 )
 sol = solve(prob, MIRK4(; jac_alg), dt = 0.05)
 plot(sol)

--- a/docs/src/tutorials/getting_started.md
+++ b/docs/src/tutorials/getting_started.md
@@ -3,8 +3,8 @@
 When ordinary differential equations has constraints over the time span, we should model the differential equations as a boundary value problem which has the form of:
 
 ```math
-\frac{du}{dt}=f(u, p, t)\\
-g(u(a),u(b))=0
+\frac{du}{dt} = f(u, p, t) \\
+g(u(a),u(b)) = 0
 ```
 
 BoundaryValueDiffEq.jl addresses three types of BVProblem.
@@ -22,10 +22,12 @@ using BoundaryValueDiffEq
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = u[1]
+    return
 end
 function bc!(res, u, p, t)
     res[1] = u(0.0)[1] - 1
     res[2] = u(1.0)[1]
+    return
 end
 tspan = (0.0, 1.0)
 u0 = [0.0, 0.0]
@@ -39,17 +41,21 @@ Since this problem only has constraints at the start and end of the time span, w
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = u[1]
+    return
 end
 function bca!(res, ua, p)
     res[1] = ua[1] - 1
+    return
 end
 function bcb!(res, ub, p)
     res[1] = ub[1]
+    return
 end
 tspan = (0.0, 1.0)
 u0 = [0.0, 0.0]
 prob = TwoPointBVProblem(
-    f!, (bca!, bcb!), u0, tspan, bcresid_prototype = (zeros(1), zeros(1)))
+    f!, (bca!, bcb!), u0, tspan, bcresid_prototype = (zeros(1), zeros(1))
+)
 sol = solve(prob, MIRK4(), dt = 0.01)
 ```
 
@@ -58,18 +64,18 @@ sol = solve(prob, MIRK4(), dt = 0.01)
 Consirder the test problem from example problems in MIRKN paper [Muir2001MonoImplicitRM](@Citet).
 
 ```math
-\begin{cases}
-y_1'(x) = y_2(x),\\
-ε y_2'(x) = -y_1(x) y_2'(x) - y_3(x) y_3'(x),\\
-ε y_3'(x) =  y_1'(x) y_3(x) - y_1(x) y_3 '(x)
-\end{cases}
+\begin{align*}
+y_1'(x) &= y_2(x),\\
+ε y_2'(x) &= -y_1(x) y_2'(x) - y_3(x) y_3'(x), \\
+ε y_3'(x) &=  y_1'(x) y_3(x) - y_1(x) y_3'(x)
+\end{align*}
 ```
 
 with initial conditions:
 
 ```math
 \begin{align*}
-y_1(0) &= y_1'(0) = y_1(1)=y_1'(1)=0, \\
+y_1(0) &= y_1'(0) = y_1(1) = y_1'(1) = 0, \\
 y_3(0) &= -1, \\
 y_3(1) &=1
 \end{align*}
@@ -82,6 +88,7 @@ function f!(ddu, du, u, p, t)
     ddu[1] = u[2]
     ddu[2] = (-u[1] * du[2] - u[3] * du[3]) / ε
     ddu[3] = (du[1] * u[3] - u[1] * du[3]) / ε
+    return
 end
 function bc!(res, du, u, p, t)
     res[1] = u(0.0)[1]
@@ -90,6 +97,7 @@ function bc!(res, du, u, p, t)
     res[4] = u(1.0)[3] - 1
     res[5] = du(0.0)[1]
     res[6] = du(1.0)[1]
+    return
 end
 u0 = [1.0, 1.0, 1.0]
 tspan = (0.0, 1.0)
@@ -102,12 +110,12 @@ sol = solve(prob, MIRKN4(), dt = 0.01)
 Consider the nonlinear semi-explicit DAE of index at most 2 in COLDAE paper [ascher1994collocation](@Citet)
 
 ```math
-\begin{cases}
-x_1' = (ε+ x_2 - \sin(t)) y + \cos(t) \\
-x_2' = \cos(t) \\
-x_3' = y \\
-0 = (x_1-p_1(t)) (y-e^t)
-\end{cases}
+\begin{align*}
+x_1' &= (ε+ x_2 - \sin(t)) y + \cos(t) \\
+x_2' &= \cos(t) \\
+x_3' &= y \\
+0 &= [x_1-p_1(t)] \left(y - e^t\right)
+\end{align*}
 ```
 
 with boundary conditions
@@ -127,15 +135,18 @@ function f!(du, u, p, t)
     du[2] = cos(t)
     du[3] = u[4]
     du[4] = (u[1] - sin(t)) * (u[4] - exp(t))
+    return
 end
 function bc!(res, u, p, t)
     res[1] = u[1]
     res[2] = u[3] - 1
     res[3] = u[2] - sin(1.0)
+    return
 end
 u0 = [0.0, 0.0, 0.0, 0.0]
 tspan = (0.0, 1.0)
-fun = BVPFunction(f!, bc!, mass_matrix = [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 0])
+mass_matrix = [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 0]
+fun = BVPFunction(f!, bc!; mass_matrix)
 prob = BVProblem(fun, u0, tspan)
 sol = solve(prob, Ascher4(zeta = [0.0, 0.0, 1.0]), dt = 0.01)
 ```

--- a/docs/src/tutorials/optimal_control.md
+++ b/docs/src/tutorials/optimal_control.md
@@ -10,22 +10,23 @@ Block move optimal control problem is an easy example of optimal control problem
 
 ### System dynamics
 
-Suppose we apply the external force $f$ on a block which can slide without friction in one dimension, its position $x$ and velocity $v$ can be described using:
+Suppose we apply the external force ``f`` on a block which can slide without friction in one dimension, its position ``x`` and velocity ``v`` can be described using:
 
 ```math
-\left\{\begin{aligned}
-&\frac{dx}{dt}=v\\
-&\frac{dv}{dt}=f
-\end{aligned}\right.
+\begin{align*}
+\frac{dx}{dt} &= v, &
+\frac{dv}{dt} &= f
+\end{align*}
 ```
 
-Since the presence of control variables $f$, we can pass our state variables and control variables together as `[state variables, control variables]`, which is `u = [x, v, f]` in the system dynamics:
+Since the presence of control variables ``f``, we can pass our state variables and control variables together as `[state variables, control variables]`, which is `u = [x, v, f]` in the system dynamics:
 
 ```julia
 function block_move!(du, u, p, t)
-    x, v, f = u[1], u[2], u[3]
+    x, v, f = u
     du[1] = v
     du[2] = f
+    return
 end
 ```
 
@@ -33,10 +34,13 @@ To tell solvers the difference between state variables and control variables, `f
 
 ### Boundary Constraints
 
-The block moves from $x = -1$ at time $t = 0$ to $x = 0$ at time $t = 1$, starting and finishing at rest:
+The block moves from ``x = -1`` at time ``t = 0`` to ``x = 0`` at time ``t = 1``, starting and finishing at rest:
 
 ```math
-x(0)=-1.0, v(0)=0, x(1)=0, v(1)=0
+\begin{align*}
+x(0) &= -1, & v(0) &= 0, \\
+x(1) &= 0, & v(1) &= 0
+\end{align*}
 ```
 
 So the boundary conditions are:
@@ -47,21 +51,22 @@ function block_move_bc!(res, u, p, t)
     res[2] = u(0.0)[2]
     res[3] = u(1.0)[1]
     res[4] = u(1.0)[2]
+    return
 end
 ```
 
 ### Cost functional
 
-We want to minimize the total energy during the whole process, so the cost functional is an integral of the applied force(Lagrange form):
+We want to minimize the total energy during the whole process, so the cost functional is an integral of the applied force (Lagrange form):
 
 ```math
-\min_{x(t),v(t),f(t)} \frac{1}{2}\int_0^1 u^2(\tau)d\tau
+\min_{x(t),v(t),f(t)} \frac{1}{2} \int_0^1 v^2(τ) \, dτ
 ```
 
-The cost functional should be defined following the interpolating style in boundary conditions, for example, use `sol(t₁)` to interpolate at `t=t₁`. Here, to express the integral cost function, we can directly use `integral(f, domain)` to integrate the integrand:
+The cost functional should be defined following the interpolating style in boundary conditions, for example, use `sol(t₁)` to interpolate at `t = t₁`. Here, to express the integral cost function, we can directly use `integral(f, domain)` to integrate the integrand:
 
 ```julia
-cost_fun(sol, p) = 0.5*integral((t, p) -> sol(t)[3]^2, (0.0, 1.0))
+cost_fun(sol, p) = 0.5 * integral((t, p) -> sol(t)[3]^2, (0.0, 1.0))
 ```
 
 As for other cost functional which need the interpolation of some exact points of the solution(Mayer form), we only need to define an OOP cost function that interpolating the solution at the specific point, for example:
@@ -83,63 +88,71 @@ So the copy-and-paste code for the block move optimal control problem is:
 
 ```julia
 using BoundaryValueDiffEqMIRK, OptimizationIpopt
-#cost_fun(sol, p) = 0.5*sum(reduce(hcat, sol.u)[3, :] .^ 2)*0.005
-cost_fun(sol, p) = 0.5*integral((t, p) -> sol(t)[3]^2, (0.0, 1.0))
+cost_fun(sol, p) = 0.5 * integral((t, p) -> sol(t)[3]^2, (0.0, 1.0))
 function block_move!(du, u, p, t)
-    x, v, f = u[1], u[2], u[3]
+    x, v, f = u
     du[1] = v
     du[2] = f
+    return
 end
 function block_move_bc!(res, u, p, t)
     res[1] = u(0.0)[1] + 1.0
     res[2] = u(0.0)[2]
     res[3] = u(1.0)[1]
     res[4] = u(1.0)[2]
+    return
 end
 tspan = (0.0, 1.0)
 u0 = [-1.0, 0.0, 6.0]
-block_move_fun = BVPFunction(block_move!, block_move_bc!; cost = cost_fun,
-    f_prototype = zeros(2), bcresid_prototype = zeros(4))
+block_move_fun = BVPFunction(
+    block_move!, block_move_bc!; cost = cost_fun,
+    f_prototype = zeros(2), bcresid_prototype = zeros(4)
+)
 block_move_prob = BVProblem(
-    block_move_fun, u0, tspan; lb = [-Inf, -Inf, -Inf], ub = [Inf, Inf, Inf])
-sol = solve(block_move_prob, MIRK4(; optimize = IpoptOptimizer()), dt = 0.002, adaptive = false)
+    block_move_fun, u0, tspan;
+    lb = [-Inf, -Inf, -Inf], ub = [Inf, Inf, Inf]
+)
+sol = solve(
+    block_move_prob, MIRK4(; optimize = IpoptOptimizer());
+    dt = 0.002, adaptive = false
+)
 ```
 
 ## Rocket Launching Optimal Control
 
 Another classical optimal control problem is the rocket launching problem(aka [Goddard Rocket problem](https://en.wikipedia.org/wiki/Goddard_problem)). Say we have a rocket with limited fuel and is launched vertically. And we want to control the final altitude of this rocket so that we can make the best of the limited fuel in rocket to get to the highest altitude. In this optimal control problem, the state variables are:
 
-  - Velocity of the rocket: $x_v(t)$
-  - Altitude of the rocket: $x_h(t)$
-  - Mass of the rocket and the fuel: $x_m(t)$
+  - Velocity of the rocket: ``x_v(t)``
+  - Altitude of the rocket: ``x_h(t)``
+  - Mass of the rocket and the fuel: ``x_m(t)``
 
 The control variable is
 
-  - Thrust of the rocket: $u_t(t)$
+  - Thrust of the rocket: ``u_t(t)``
 
 The dynamics of the launching can be formulated with three differential equations:
 
 ```math
-\left\{\begin{aligned}
-&\frac{dx_v}{dt}=\frac{u_t-drag(x_h,x_v)}{x_m}-g(x_h)\\
-&\frac{dx_h}{dt}=x_v\\
-&\frac{dx_m}{dt}=-\frac{u_t}{c}
-\end{aligned}\right.
+\begin{align*}
+\frac{dx_v}{dt} &= \frac{u_t - \mathrm{drag}(x_h,x_v)}{x_m}-g(x_h)\\
+\frac{dx_h}{dt} &= x_v\\
+\frac{dx_m}{dt} &= -\frac{u_t}{c}
+\end{align*}
 ```
 
-where the drag $D(x_h,x_v)$ is a function of altitude and velocity:
+where the drag ``D(x_h,x_v)`` is a function of altitude and velocity:
 
 ```math
-D(x_h,x_v)=D_c\cdot x_v^2\cdot\exp^{h_c(\frac{x_h-x_h(0)}{x_h(0)})}
+D(x_h,x_v) = D_c ⋅ x_v^2 ⋅ \exp\left[h_c \left(\frac{x_h}{x_h(0)} - 1\right)\right]
 ```
 
-gravity $g(x_h)$ is a function of altitude:
+gravity ``g(x_h)`` is a function of altitude:
 
 ```math
-g(x_h)=g_0\cdot (\frac{x_h(0)}{x_h})^2
+g(x_h) = g_0\cdot \left(\frac{x_h(0)}{x_h}\right)^2
 ```
 
-$c$ is a constant. Suppose the final time is $T$, we here want to maximize the final altitude $x_h(T)$:
+``c`` is a constant. Suppose the final time is ``T``, we here want to maximize the final altitude ``x_h(T)``:
 
 ```math
 \max x_h(T)
@@ -149,10 +162,10 @@ The inequality constraints for the state variables and control variables are:
 
 ```math
 \left\{\begin{aligned}
-&x_v>0\\
-&x_h>0\\
-&m_T<x_m<m_0\\
-&0<u_t<u_{t\text{max}}
+& x_v > 0\\
+& x_h > 0\\
+& m_T < x_m < m_0\\
+& 0 < u_t < u_{t\text{max}}
 \end{aligned}\right.
 ```
 
@@ -179,22 +192,31 @@ g(x_h) = g_0 * (h_0 / x_h)^2
 function rocket_launch!(du, u, p, t)
     # u_t is the control variable (thrust)
     x_v, x_h, x_m, u_t = u[1], u[2], u[3], u[4]
-    du[1] = (u_t-drag(x_h, x_v))/x_m - g(x_h)
+    du[1] = (u_t - drag(x_h, x_v)) / x_m - g(x_h)
     du[2] = x_v
-    du[3] = -u_t/c
+    du[3] = -u_t / c
+    return
 end
 function rocket_launch_bc!(res, u, p, t)
     res[1] = u(0.0)[1] - v_0
     res[2] = u(0.0)[2] - h_0
     res[3] = u(0.0)[3] - m_0
     res[4] = u(0.2)[4] - 0.0
+    return
 end
 cost_fun(u, p) = -u(0.2)[2]
 u0 = [v_0, h_0, m_T, 3.0]
-rocket_launch_fun = BVPFunction(rocket_launch!, rocket_launch_bc!; cost = cost_fun, f_prototype = zeros(3))
+rocket_launch_fun = BVPFunction(
+    rocket_launch!, rocket_launch_bc!; cost = cost_fun, f_prototype = zeros(3)
+)
 rocket_launch_prob = BVProblem(
-    rocket_launch_fun, u0, tspan; lb = [0.0, h_0, m_T, 0.0], ub = [Inf, Inf, m_0, u_t_max])
-sol = solve(rocket_launch_prob, MIRK4(; optimize = IpoptOptimizer()); dt = Δt, adaptive = false)
+    rocket_launch_fun, u0, tspan;
+    lb = [0.0, h_0, m_T, 0.0], ub = [Inf, Inf, m_0, u_t_max]
+)
+sol = solve(
+    rocket_launch_prob, MIRK4(; optimize = IpoptOptimizer());
+    dt = Δt, adaptive = false
+)
 
 u = reduce(hcat, sol.u)
 v, h, m, c = u[1, :], u[2, :], u[3, :], u[4, :]
@@ -218,67 +240,66 @@ Similar optimal control problem solving can also be deployed in JuMP.jl and Infi
 The dynamic equation of the motion of cart-pole swing-up problem are given by:
 
 ```math
-
 \begin{bmatrix}
 \ddot{x} \\
-\ddot{\theta}
+\ddot{θ}
 \end{bmatrix}
 
 \begin{bmatrix}
-\cos\theta & \ell \\
-m_1 + m_2 & m_2 \ell \cos\theta
+\cos θ & \ell \\
+m_1 + m_2 & m_2 \ell \cos θ
 \end{bmatrix}^{-1}
 \begin{bmatrix}
-
-  - g \sin\theta \\
-    F + m_2 \ell \dot{\theta}^2 \sin\theta
-    \end{bmatrix}
+  - g \sin θ \\
+    F + m_2 \ell \dot{\theta}^2 \sin θ
+\end{bmatrix}
 ```
 
-where $x$ is the location of the cart, $\theta$ is the pole angle, $m_1$ is the cart mass, $m_2$ is the pole mass, $l$ is the pole length.
+where ``x`` is the location of the cart, ``θ`` is the pole angle, ``m_1`` is the cart mass, ``m_2`` is the pole mass, ``l`` is the pole length.
 
 By converting the dynamics to first order equations, we can get the formulation:
 
 ```math
 \begin{bmatrix}
 \dot{x} \\
-\dot{\theta} \\
+\dot{θ} \\
 \ddot{x} \\
-\ddot{\theta} \\
+\ddot{θ} \\
 \dot{e}
 \end{bmatrix}
 
 f\!\left(
 \begin{bmatrix}
-x \\ \theta \\ \dot{x} \\ \dot{\theta} \\ e
+x \\ θ \\ \dot{x} \\ \dot{θ} \\ e
 \end{bmatrix}
 \right)
 
 \begin{bmatrix}
 \dot{x} \\
-\dot{\theta} \\
-\dfrac{-m_2 g \sin\theta \cos\theta - \left(F + m_2 \ell \dot{\theta}^2 \sin\theta\right)}
-{m_2 \cos^2\theta - (m_1 + m_2)} \\
-\dfrac{(m_1 + m_2) g \sin\theta + \cos\theta \left(F + m_2 \ell \dot{\theta}^2 \sin\theta\right)}
-{m_2 \ell \cos^2\theta - (m_1 + m_2)\ell} \\
+\dot{θ} \\
+\dfrac{-m_2 g \sin θ \cos θ - \left(F + m_2 \ell \dot{θ}^2 \sin θ\right)}{m_2 \cos^2 θ - (m_1 + m_2)} \\
+\dfrac{(m_1 + m_2) g \sin θ + \cos θ \left(F + m_2 \ell \dot{θ}^2 \sin θ\right)}{m_2 \ell \cos^2 θ - (m_1 + m_2)\ell} \\
 F^2
 \end{bmatrix}
 ```
 
-and the initial conditions of all states at $t=0$ are all zero, the boundary conditions at time $t_f$ are:
+and the initial conditions of all states at ``t = 0`` are all zero, the boundary conditions at time ``t_f`` are:
 
 ```math
-x_f=d, \dot{x_f}=0, \theta_f=\pi, \dot{\theta_f}=0
+\begin{align*}
+x_f &= d, & \dot{x}_f &= 0, \\
+θ_f &= π, & \dot{θ}_f &= 0
+\end{align*}
 ```
 
 The target cost function is defined as the "energy" so the target cost function is:
 
 ```math
-\min J=\int\dot{e}dt=F
+\min J = \int \dot{e} \, dt = F
 ```
 
 ```@example cart_pole
-using BoundaryValueDiffEqMIRK, OptimizationIpopt, Plots
+using BoundaryValueDiffEqMIRK, OptimizationIpopt
 m_1 = 1.0                      # Cart mass
 m_2 = 0.3                      # Pole mass
 l = 0.5                        # Pole length
@@ -288,12 +309,14 @@ t_f = 2.0                      # Final time
 g = 9.81                       # Gravity constant
 tspan = (t_0, t_f)
 function cart_pole!(du, u, p, t)
-    x, θ, dx, dθ, f = u[1], u[2], u[3], u[4], u[5]
+    x, θ, dx, dθ, f = u
     du[1] = dx
     du[2] = dθ
-    du[3] = (- m_2*g*sin(θ)*cos(θ) - (f + m_2*l*θ^2*sin(θ))) / (m_2*l*cos(θ)^2 - m_1 - m_2)
-    du[4] = ((m_1 + m_2)*g*sin(θ) + cos(θ)*(f + m_1*l*dθ^2*sin(θ))) /
-            (m_2*l*cos(θ)^2 - (m_1 + m_2)*l)
+    du[3] = (- m_2 * g * sin(θ) * cos(θ) - (f + m_2 * l * θ^2 * sin(θ))) /
+        (m_2 * l * cos(θ)^2 - m_1 - m_2)
+    du[4] = ((m_1 + m_2) * g * sin(θ) + cos(θ) * (f + m_1 * l * dθ^2 * sin(θ))) /
+        (m_2 * l * cos(θ)^2 - (m_1 + m_2) * l)
+    return
 end
 
 function cart_pole_bc!(du, u, p, t)
@@ -304,25 +327,39 @@ function cart_pole_bc!(du, u, p, t)
     du[5] = u(t_0)[4] - 0.0
     du[6] = u(t_f)[3] - 0.0
     du[7] = u(t_f)[4] - 0.0
+    return
 end
 cost_fun(u, p) = u(t_f)[5]
 u0 = [0.0, 0.0, 0.0, 0.0, 10.0]
-cart_pole_fun = BVPFunction(cart_pole!, cart_pole_bc!; cost = cost_fun,
-    bcresid_prototype = zeros(7), f_prototype = zeros(4))
-cart_pole_prob = BVProblem(cart_pole_fun, u0, tspan; lb = [-2.0, -Inf, -Inf, -Inf, -20.0],
-    ub = [2.0, Inf, Inf, Inf, 20.0])
-sol = solve(cart_pole_prob, MIRK4(; optimize = IpoptOptimizer()); dt = 0.01, adaptive = false)
+cart_pole_fun = BVPFunction(
+    cart_pole!, cart_pole_bc!; cost = cost_fun,
+    bcresid_prototype = zeros(7), f_prototype = zeros(4)
+)
+cart_pole_prob = BVProblem(
+    cart_pole_fun, u0, tspan;
+    lb = [-2.0, -Inf, -Inf, -Inf, -20.0],
+    ub = [2.0, Inf, Inf, Inf, 20.0]
+)
+sol = solve(
+    cart_pole_prob, MIRK4(; optimize = IpoptOptimizer());
+    dt = 0.01, adaptive = false
+)
+```
 
+We can now animate the solution of the BVP:
+
+```@example cart_pole
+using Plots
 t = sol.t
 x, theta, dx, dtheta, f = sol[1, :], sol[2, :], sol[3, :], sol[4, :], sol[5, :]
 
-L = 1.0    # pole length (visual)
+L = 1.0         # pole length (visual)
 cart_w = 0.4    # cart width
 cart_h = 0.2    # cart height
 
 # Precompute pole tip coordinates
 px = x .+ L .* sin.(theta)
-py = cart_h/2 .- L .* cos.(theta)
+py = cart_h / 2 .- L .* cos.(theta)
 
 # Axis limits (a bit margin around the cart trajectory)
 xmin = minimum(x) - 2L
@@ -336,23 +373,26 @@ anim = @animate for k in eachindex(t)
     pole_y = py[k]
 
     # Base plot / axis
-    plot(; xlim = (xmin, xmax), ylim = (ymin, ymax), aspect_ratio = :equal,
-        legend = false, title = "Cart–Pole (t = $(round(t[k], digits=2)) s)")
+    plot(;
+        xlim = (xmin, xmax), ylim = (ymin, ymax), aspect_ratio = :equal,
+        legend = false, title = "Cart–Pole (t = $(round(t[k], digits = 2)) s)"
+    )
 
     # Draw ground
     plot!([xmin, xmax], [0, 0], lw = 2, color = :black)
 
     # Draw cart as a rectangle
     rect = Shape(
-        [cart_x - cart_w/2, cart_x + cart_w/2, cart_x + cart_w/2, cart_x - cart_w/2],
-        [0, 0, cart_h, cart_h])
+        [cart_x - cart_w / 2, cart_x + cart_w / 2, cart_x + cart_w / 2, cart_x - cart_w / 2],
+        [0, 0, cart_h, cart_h]
+    )
     plot!(rect, color = :gray)
 
     # Draw pole as a line from cart center to tip
-    plot!([cart_x, pole_x], [cart_h/2, pole_y], lw = 3, color = :red)
+    plot!([cart_x, pole_x], [cart_h / 2, pole_y], lw = 3, color = :red)
 
     # Draw pivot point
-    scatter!([cart_x], [cart_h/2], ms = 4, color = :black)
+    scatter!([cart_x], [cart_h / 2], ms = 4, color = :black)
 end
 
 # Save GIF

--- a/docs/src/tutorials/solve_nlls_bvp.md
+++ b/docs/src/tutorials/solve_nlls_bvp.md
@@ -30,6 +30,7 @@ using BoundaryValueDiffEq, Plots
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = -u[1]
+    return
 end
 function bc!(resid, sol, p, t)
     solₜ₁ = sol(0.0)
@@ -37,11 +38,12 @@ function bc!(resid, sol, p, t)
     resid[1] = solₜ₁[1]
     resid[2] = solₜ₂[1] - 1
     resid[3] = solₜ₂[2] + 1.729109
+    return
 end
 tspan = (0.0, 100.0)
 u0 = [0.0, 1.0]
 prob = BVProblem(BVPFunction(f!, bc!; bcresid_prototype = zeros(3)), u0, tspan)
-sol = solve(prob, MIRK4(), dt = 0.01, abstol = 1e-3)
+sol = solve(prob, MIRK4(), dt = 0.01, abstol = 1.0e-3)
 plot(sol)
 ```
 
@@ -51,29 +53,32 @@ Since this BVP imposes constraints only at the two endpoints, we can use `TwoPoi
 function f!(du, u, p, t)
     du[1] = u[2]
     du[2] = -u[1]
+    return
 end
 bca!(resid, ua, p) = (resid[1] = ua[1])
 bcb!(resid, ub, p) = (resid[1] = ub[1] - 1; resid[2] = ub[2] + 1.729109)
-bvpfun = BVPFunction(f!, (bca!, bcb!); twopoint = Val(true),
-    bcresid_prototype = (zeros(1), zeros(2)))
+bvpfun = BVPFunction(
+    f!, (bca!, bcb!); twopoint = Val(true),
+    bcresid_prototype = (zeros(1), zeros(2))
+)
 prob = TwoPointBVProblem(bvpfun, u0, tspan)
 ```
 
 ## Solve Underdetermined BVP
 
-Let's see an example of underdetermined BVP, consider an horizontal metal beam of length $L$ subject to a vertical load $q(x)$ per unit length, the resulting beam displacement satisfies the differential equation
+Let's see an example of underdetermined BVP, consider an horizontal metal beam of length ``L`` subject to a vertical load ``q(x)`` per unit length, the resulting beam displacement satisfies the differential equation
 
 ```math
-EIy'(x)=q(x)
+E I y'(x) = q(x)
 ```
 
-with boundary condition $y(0)=y(L)=0$, $E$ is the Young's modulus and $I$ is the moment of inertia of the beam's cross section. Here we consider the simplified version and transform this BVP into a first order BVP system:
+with boundary condition ``y(0) = y(L) = 0``, ``E`` is the Young's modulus and ``I`` is the moment of inertia of the beam's cross section. Here we consider the simplified version and transform this BVP into a first order BVP system:
 
 ```math
 \begin{align*}
-y_1' &= y_2\\
-y_2' &= y_3\\
-y_3' &= y_4\\
+y_1' &= y_2 \\
+y_2' &= y_3 \\
+y_3' &= y_4 \\
 y_4' &= 0
 \end{align*}
 ```
@@ -85,12 +90,14 @@ function f!(du, u, p, t)
     du[2] = u[3]
     du[3] = u[4]
     du[4] = 0
+    return
 end
 function bc!(resid, sol, p, t)
     solₜ₁ = sol(0.0)
     solₜ₂ = sol(1.0)
     resid[1] = solₜ₁[1]
     resid[2] = solₜ₂[1]
+    return
 end
 xspan = (0.0, 1.0)
 u0 = [0.0, 1.0, 0.0, 1.0]
@@ -109,12 +116,15 @@ function f!(du, u, p, t)
     du[2] = u[3]
     du[3] = u[4]
     du[4] = 0
+    return
 end
 bca!(resid, ua, p) = (resid[1] = ua[1])
 bcb!(resid, ub, p) = (resid[1] = ub[1])
 xspan = (0.0, 1.0)
 u0 = [0.0, 1.0, 0.0, 1.0]
-bvpfun = BVPFunction(f!, (bca!, bcb!); twopoint = Val(true),
-    bcresid_prototype = ( zeros(1), zeros(1)))
+bvpfun = BVPFunction(
+    f!, (bca!, bcb!); twopoint = Val(true),
+    bcresid_prototype = (zeros(1), zeros(1))
+)
 prob = TwoPointBVProblem(bvpfun, u0, xspan)
 ```

--- a/docs/src/tutorials/unknown_parameters.md
+++ b/docs/src/tutorials/unknown_parameters.md
@@ -5,31 +5,31 @@ When there are unknown parameters in boundary value problems, we can estimate th
 Let's walk through this functionality with an intuitive example. In the following tutorial, we use the [Mathieu equation](https://en.wikipedia.org/wiki/Mathieu_wavelet) which is a second-order differential equation:
 
 ```math
-y''+(\lambda-2q\cos(2x))y=0
+y'' + (λ - 2q\cos(2x)) y = 0
 ```
 
-where $\lambda$ is the unknown parameter we wish to estimate, `q` is a known real-valued parameter, with boundary conditions when `q=5`:
+where ``λ`` is the unknown parameter we wish to estimate, `q` is a known real-valued parameter, with boundary conditions when `q = 5`:
 
 ```math
-y'(0)=0,\ y'(\pi)=0
+y'(0)=0,\ y'(π) =0
 ```
 
 The second-order BVP can be transformed into a first-order system of BVP:
 
 ```math
-\begin{cases}
-y_1'=y_2\\
-y_2'=-(\lambda-2q\cos(2x))y_1
-\end{cases}
+\begin{align*}
+y_1' &= y_2 \\
+y_2' &= -(λ - 2q\cos(2x)) y_1
+\end{align*}
 ```
 
 with boundary conditions of
 
 ```math
-y_2(0)=0,\ y_2(\pi)=0
+y_2(0) = 0, \ y_2(π) = 0
 ```
 
-It is worthnoting that in this system, while we have two differetial equations, it isn't enough to estimate the unknown parameters and guarantee a unique numerical solution with only two given boundary conditions. While under the hood, the parameters are estimated simultaneously with the numerical solution, it makes the boundary value problem an underconstrained BVP if the number of constraints are equal to the number of states, which may result in more than one solution. So we should provide additional constraint $y(0)=1$ from the original equation to make sure unique numerical solution and the estimated parameters are we actually wanted.
+It is worthnoting that in this system, while we have two differetial equations, it isn't enough to estimate the unknown parameters and guarantee a unique numerical solution with only two given boundary conditions. While under the hood, the parameters are estimated simultaneously with the numerical solution, it makes the boundary value problem an underconstrained BVP if the number of constraints are equal to the number of states, which may result in more than one solution. So we should provide additional constraint ``y(0)=1`` from the original equation to make sure unique numerical solution and the estimated parameters are we actually wanted.
 
 With BoundaryValueDiffEq.jl, it's easy to solve boundary value problems with unknown parameters, we can just specify `tune_parameters=true` when constructing the BVP and provide the guess of the unknown parameters in `prob.p`, for example, to estimate the unknown parameters in the above BVP system:
 
@@ -38,18 +38,23 @@ using BoundaryValueDiffEq, Plots
 tspan = (0.0, pi)
 function f!(du, u, p, t)
     du[1] = u[2]
-    du[2] = -(p[1] - 10 * cos(2 * t)) * u[1]
+    du[2] = -(p[1] - 10 * cos(2t)) * u[1]
+    return
 end
 function bca!(res, u, p)
     res[1] = u[2]
     res[2] = u[1] - 1.0
+    return
 end
 function bcb!(res, u, p)
     res[1] = u[2]
+    return
 end
 guess(p, t) = [cos(4t); -4sin(4t)]
-bvp = TwoPointBVProblem(f!, (bca!, bcb!), guess, tspan, [15.0],
-    bcresid_prototype = (zeros(2), zeros(1)), tune_parameters = true)
+bvp = TwoPointBVProblem(
+    f!, (bca!, bcb!), guess, tspan, [15.0],
+    bcresid_prototype = (zeros(2), zeros(1)), tune_parameters = true
+)
 sol = solve(bvp, MIRK4(), dt = 0.05)
 plot(sol)
 ```

--- a/lib/BoundaryValueDiffEqCore/src/default_internal_solve.jl
+++ b/lib/BoundaryValueDiffEqCore/src/default_internal_solve.jl
@@ -45,8 +45,10 @@ function __FastShortcutBVPCompatibleNonlinearPolyalg(
 end
 
 """
-    __FastShortcutNonlinearPolyalg(T = Float64; concrete_jac = nothing, linsolve = nothing,
-        autodiff = nothing)
+    __FastShortcutNonlinearPolyalg(
+        T = Float64; concrete_jac = nothing, linsolve = nothing,
+        autodiff = nothing
+    )
 
 Build the default nonlinear solver polyalgorithm used when a BVP algorithm does not supply
 an explicit nonlinear solver.

--- a/lib/BoundaryValueDiffEqCore/src/verbosity.jl
+++ b/lib/BoundaryValueDiffEqCore/src/verbosity.jl
@@ -221,41 +221,47 @@ solve(prob, MIRK4(); verbose = BVPVerbosity(All()))
 
 ```julia
 # Show only BVPSOL convergence issues
-solve(prob, BVPSOL(); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     bvpsol_convergence = WarnLevel(),
     # All others default to Silent in None preset
-))
+)
+solve(prob, BVPSOL(); verbose)
 
 # Silence initial guess warnings but keep solver failures
-solve(prob, MultipleShooting(10); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     Standard(),
     multiple_shooting_initial_guess = Silent()
-))
+)
+solve(prob, MultipleShooting(10); verbose)
 
 # Only show linear algebra issues
-solve(prob, BVPSOL(); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     None(),
     bvpsol_linear_solver = WarnLevel(),
     colnew_matrix = WarnLevel()
-))
+)
+solve(prob, BVPSOL(); verbose)
 
 # Control NonlinearSolve verbosity independently
-solve(prob, MIRK4(); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     None(),  # Silence BVP messages
     nonlinear_verbosity = All()  # Show all NonlinearSolve convergence info
-))
+)
+solve(prob, MIRK4(); verbose)
 
 # Silence NonlinearSolve but keep BVP messages
-solve(prob, MIRK4(); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     Standard(),  # Standard BVP messages
     nonlinear_verbosity = None()  # No NonlinearSolve output
-))
+)
+solve(prob, MIRK4(); verbose)
 
 # Control Optimization.jl verbosity independently
-solve(prob, MIRK4(optimize = NLopt.LN_NELDERMEAD()); verbose = BVPVerbosity(
+verbose = BVPVerbosity(
     None(),  # Silence BVP messages
     optimization_verbosity = All()  # Show all Optimization.jl convergence info
-))
+)
+solve(prob, MIRK4(optimize = NLopt.LN_NELDERMEAD()); verbose)
 ```
 
 ## Using Groups

--- a/lib/BoundaryValueDiffEqShooting/src/algorithms.jl
+++ b/lib/BoundaryValueDiffEqShooting/src/algorithms.jl
@@ -71,8 +71,10 @@ end
 end
 
 """
-    MultipleShooting(; nshoots::Int, ode_alg = nothing, nlsolve = nothing,
-        optimize = nothing, grid_coarsening = true, jac_alg = nothing) -> MultipleShooting
+    MultipleShooting(;
+            nshoots::Int, ode_alg = nothing, nlsolve = nothing,
+            optimize = nothing, grid_coarsening = true, jac_alg = nothing
+        ) -> MultipleShooting
     MultipleShooting(nshoots::Int; kwargs...)
     MultipleShooting(nshoots::Int, ode_alg; kwargs...)
     MultipleShooting(nshoots::Int, ode_alg, nlsolve; kwargs...)

--- a/lib/BoundaryValueDiffEqShooting/src/sparse_jacobians.jl
+++ b/lib/BoundaryValueDiffEqShooting/src/sparse_jacobians.jl
@@ -1,9 +1,13 @@
 # For Multiple Shooting
 """
-    __generate_sparse_jacobian_prototype(::MultipleShooting, ::StandardBVProblem,
-        bcresid_prototype, u0, N::Int, nshoots::Int)
-    __generate_sparse_jacobian_prototype(::MultipleShooting, ::TwoPointBVProblem,
-        bcresid_prototype, u0, N::Int, nshoots::Int)
+    __generate_sparse_jacobian_prototype(
+        ::MultipleShooting, ::StandardBVProblem,
+        bcresid_prototype, u0, N::Int, nshoots::Int
+    )
+    __generate_sparse_jacobian_prototype(
+        ::MultipleShooting, ::TwoPointBVProblem,
+        bcresid_prototype, u0, N::Int, nshoots::Int
+    )
 
 Generate a prototype of the sparse Jacobian matrix for the BVP problem.
 """


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Run runic, clean up/reformat some TeX, and refactor some code for readability. Also fixed a typo where a length variable was accidentally included in example code (cart-pole example in optimal control)