### PR TITLE
Scope the Ascher/FIRK names() tests to each package's own API

### DIFF
--- a/lib/BoundaryValueDiffEqAscher/test/Core/ascher_basic_tests.jl
+++ b/lib/BoundaryValueDiffEqAscher/test/Core/ascher_basic_tests.jl
@@ -2,7 +2,12 @@ using BoundaryValueDiffEqAscher
 using Test
 
 @testset "Public API" begin
-    @test Set(names(BoundaryValueDiffEqAscher)) == Set(
+    # Only the names this package owns; the rest of `names` is the reexported API
+    # documented elsewhere, pinned against `ASCHER_REEXPORTS` by test/qa/qa.jl.
+    owned = filter(names(BoundaryValueDiffEqAscher)) do name
+        which(BoundaryValueDiffEqAscher, name) === BoundaryValueDiffEqAscher
+    end
+    @test Set(owned) == Set(
         (
             :Ascher1,
             :Ascher2,

--- a/lib/BoundaryValueDiffEqFIRK/test/public_facade_tests.jl
+++ b/lib/BoundaryValueDiffEqFIRK/test/public_facade_tests.jl
@@ -53,11 +53,21 @@ end
             :LobattoIIIc2, :LobattoIIIc3, :LobattoIIIc4, :LobattoIIIc5,
         ]
     )
-    documented_facade = Set([:BVProblem, :TwoPointBVProblem, :solve])
-    actual_exports = Set(names(DocumentedFIRKWorkflow.FIRK))
-    delete!(actual_exports, nameof(DocumentedFIRKWorkflow.FIRK))
+    # Only the names the package owns; the rest of `names` is the reexported API
+    # documented elsewhere, pinned against `FIRK_REEXPORTS` by test/qa/qa.jl.
+    owned = Set(
+        filter(names(DocumentedFIRKWorkflow.FIRK)) do name
+            which(DocumentedFIRKWorkflow.FIRK, name) === DocumentedFIRKWorkflow.FIRK
+        end
+    )
+    delete!(owned, nameof(DocumentedFIRKWorkflow.FIRK))
 
-    @test actual_exports == union(firk_algorithms, documented_facade)
+    @test owned == firk_algorithms
+
+    # The names the workflow module above spells unqualified have to reach it from
+    # `using BoundaryValueDiffEqFIRK` alone.
+    documented_facade = [:BVProblem, :TwoPointBVProblem, :solve]
+    @test all(name -> isdefined(DocumentedFIRKWorkflow, name), documented_facade)
 
     sol, two_point_sol = DocumentedFIRKWorkflow.solve_documented_problems()
     @test isapprox(sol(0.0)[1], 1.0; atol = 1.0e-6)


### PR DESCRIPTION
## What changed and why

`7fda9de` restored the documented reexport surface across the BVP sublibraries but left behind the two `names()` guards that `1432eb6` and `5b9030d` had written against the stripped, solver-only surface. Both have been failing on `master` ever since — Sublibrary CI path-filtering just kept hiding it, while the Downgrade Sublibraries lane runs Ascher/FIRK unconditionally and goes red.

The reexport surface is already pinned exactly, in one place: each sublibrary's `test/qa/qa.jl` hands `ASCHER_REEXPORTS` / `FIRK_REEXPORTS` to `run_qa` as `reexports_allow` (no public name outside the list) and to `test_reexport_surface` (every name in the list is reachable). So these two tests should not restate that list — that would duplicate the audit, and it would drag the monorepo root's `test/qa/reexports.jl` into test groups outside `test/qa`.

Instead both tests now filter `names` by `which(pkg, name) === pkg`, leaving each package's own public API — the invariant they were actually written to guard, which no longer moves when the reexport list does. The FIRK facade test additionally asserts that the three names its `DocumentedFIRKWorkflow` module spells unqualified (`BVProblem`, `TwoPointBVProblem`, `solve`) really are in scope from `using BoundaryValueDiffEqFIRK` alone, which is the property that test is named for.

Two files, +20/-5. No source or `Project.toml` changes.

## Verification

All runs on Julia 1.12.4, sublibrary test environments.

**BoundaryValueDiffEqAscher — failing before the fix** (`master` @ `628472d`, `julia --project=. -e 'using Pkg; Pkg.test()'`):

```
Public API: Test Failed at lib/BoundaryValueDiffEqAscher/test/Core/ascher_basic_tests.jl:5
  Expression: Set(names(BoundaryValueDiffEqAscher)) == Set((:Ascher1, :Ascher2, :Ascher3, :Ascher4, :Ascher5, :Ascher6, :Ascher7, :BoundaryValueDiffEqAscher))
   Evaluated: Set([:NoErrorControl, :Ascher5, :Ascher1, :Ascher6, :AutoSparse, :integral, :BVPVerbosity, :SequentialErrorControl, :TrustRegion, :AutoFiniteDiff  …  ]) == Set([:Ascher2, :Ascher7, :Ascher4, :Ascher5, :Ascher1, :Ascher3, :Ascher6, :BoundaryValueDiffEqAscher])

Test Summary:                             | Pass  Fail  Total      Time
Ascher Basic Tests                        |   60     1     61  29m55.4s
  Public API                              |          1      1      3.1s
```

**Passing after:**

```
Test Summary:      | Pass  Total      Time
Ascher Basic Tests |   61     61  29m36.8s
     Testing BoundaryValueDiffEqAscher tests passed
```

**BoundaryValueDiffEqFIRK — failing before the fix** (`BOUNDARYVALUEDIFFEQ_TEST_GROUP=PUBLIC_FACADE`):

```
Documented FIRK public facade: Test Failed at lib/BoundaryValueDiffEqFIRK/test/public_facade_tests.jl:60
  Expression: actual_exports == union(firk_algorithms, documented_facade)

Test Summary:                   | Pass  Fail  Total     Time
FIRK Public Facade Tests        |    4     1      5  1m36.6s
  Documented FIRK public facade |    4     1      5  1m29.0s
```

**Passing after:**

```
Test Summary:            | Pass  Total     Time
FIRK Public Facade Tests |    6      6  1m36.9s
     Testing BoundaryValueDiffEqFIRK tests passed
```

**QA groups still green** (these are what actually pin the reexport lists, so they had to be re-run):

```
BOUNDARYVALUEDIFFEQ_TEST_GROUP=QA, BoundaryValueDiffEqAscher
Quality Assurance |   80     80  1m12.0s

BOUNDARYVALUEDIFFEQ_TEST_GROUP=QA, BoundaryValueDiffEqFIRK
Quality Assurance |   84     84  1m36.7s
```

Runic (`Runic.main --check --diff`) and `typos` are clean on both changed files.

## What I dropped from the previous revision of this PR

The earlier version of this branch also floored `SciMLPublic = "1.3"` in `lib/BoundaryValueDiffEqCore/Project.toml` and bumped Core to 2.8.3. That is not justified: the only difference between SciMLPublic 1.2.4 and 1.3.0 is a `PrecompileTools` `@setup_workload` block —

```
+using PrecompileTools: @compile_workload, @setup_workload
+@setup_workload begin
+    @compile_workload begin
+        _get_symbols(:foo)
+        _get_symbols(:(foo, bar))
+        macroexpand(@__MODULE__, :(@public foo))
+    end
+end
```

— no API change, nothing `@public` depends on. Flooring it would cut 1.0–1.2 out of downgrade resolution and out of downstream resolves for no reason, and "matches the current resolve" is not a reason to raise a compat bound. Dropped, so this PR is test-only. (The branch is still named `compat/scimlpublic-1.3`; renaming it closes the PR on GitHub, so the name is just stale.)

## What I did not verify

- The Downgrade Sublibraries matrix itself — that is what CI is for; I ran the same test groups it runs, at the resolved (not floored) versions.
- The root `BoundaryValueDiffEq` suite and the docs build: this PR touches no source, no docstrings, and no `docs/`.
- MIRK / MIRKN / Shooting: `grep` confirms Ascher and FIRK are the only two sublibraries with a `names()` assertion, so nothing else was stale.

## Something a reviewer should push back on

Separate, pre-existing, **not** fixed here: every `lib/*/test/qa/qa.jl` reaches the monorepo root with `include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))`. A registered sublibrary tarball contains only `lib/<pkg>/`, so that path does not exist for an installed package:

```
$ grep -n reexports ~/.julia/packages/BoundaryValueDiffEqAscher/R5fx0/test/qa/qa.jl
5:include(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "reexports.jl"))
$ ls ~/.julia/packages/BoundaryValueDiffEqAscher/R5fx0/../../../test
ls: cannot access ...: No such file or directory
```

i.e. `Pkg.test("BoundaryValueDiffEqAscher")` against the registry errors in its QA group today. This PR deliberately does not extend that pattern into the Core / PUBLIC_FACADE groups, but fixing it properly (per-package allow-lists, or shipping the shared list as package content) is its own PR.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])
https://claude.ai/code/session_01K6UnSvbRoZZaeS3M4pktj3
