### PR TITLE
Use specific `dt` type to check for positive `dt`

### DIFF
--- a/lib/BoundaryValueDiffEqCore/src/utils.jl
+++ b/lib/BoundaryValueDiffEqCore/src/utils.jl
@@ -320,6 +320,9 @@ function __resize!(x::AbstractVectorOfArray, n, M)
     return x
 end
 
+"Helper function to check if a positive `dt` was passed, switched on by `check`."
+positive_dt(check, dt) = check && dt ≤ zero(dt) && throw(ArgumentError("dt must be positive"))
+
 ## Problem with Initial Guess
 """
     __extract_problem_details(prob; kwargs...)
@@ -332,7 +335,7 @@ function __extract_problem_details(prob; kwargs...)
 end
 function __extract_problem_details(prob, u0::Number; dt = 0.0, check_positive_dt::Bool = false, kwargs...)
     # Scalar BVP
-    check_positive_dt && dt ≤ 0 && throw(ArgumentError("dt must be positive"))
+    positive_dt(check_positive_dt, dt)
     t₀, t₁ = prob.tspan
     return Val(true), typeof(u0), 1, Int(cld(t₁ - t₀, dt)), [u0]
 end
@@ -351,7 +354,7 @@ function __extract_problem_details(
         check_positive_dt::Bool = false, tune_parameters::Bool = false
     )
     # Problem does not have Initial Guess
-    check_positive_dt && dt ≤ 0 && throw(ArgumentError("dt must be positive"))
+    positive_dt(check_positive_dt, dt)
     t₀, t₁ = prob.tspan
     if tune_parameters
         prob.p isa SciMLBase.NullParameters &&
@@ -366,7 +369,7 @@ function __extract_problem_details(
         tune_parameters::Bool = false
     ) where {F <: Function}
     # Problem passes in a initial guess function
-    check_positive_dt && dt ≤ 0 && throw(ArgumentError("dt must be positive"))
+    positive_dt(check_positive_dt, dt)
 
     u0 = __initial_guess(f, prob.p, prob.tspan[1]; tune_parameters = tune_parameters)
     t₀, t₁ = prob.tspan


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Hardcoding an integer 0 fails if dt has physical units, so using `zero(dt)` instead. Also moved the check logic into a function so that the condition didn't need to be search-and-replaced.