### PR TITLE
Allow LinearSolve 5 in the FIRK test environment

### DIFF
--- a/lib/BoundaryValueDiffEqFIRK/Project.toml
+++ b/lib/BoundaryValueDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "BoundaryValueDiffEqFIRK"
 uuid = "85d9eb09-370e-4000-bb32-543851f73618"
 authors = ["Qingyu Qu <erikqqy123@gmail.com>"]
-version = "1.19.1"
+version = "1.19.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -41,7 +41,7 @@ FastAlmostBandedMatrices = "0.1.4"
 FastClosures = "0.3.2"
 ForwardDiff = "1"
 LinearAlgebra = "1.10"
-LinearSolve = "4.2"
+LinearSolve = "4.2, 5"
 NonlinearSolveFirstOrder = "2"
 OrdinaryDiffEqRosenbrock = "2"
 PreallocationTools = "1.7.1"


### PR DESCRIPTION
## What changed and why

`lib/BoundaryValueDiffEqFIRK/Project.toml` caps the test target at `LinearSolve = "4.2"`, i.e. LinearSolve 4.x only. NonlinearSolveBase 2.36.0 and later require LinearSolve 5, so the resolver walks NonlinearSolveBase back to **2.35.0** — the last release before https://github.com/SciML/NonlinearSolve.jl/pull/1055 replaced the raw `z = -Jᵤ \ Jₚ` in `nonlinearsolve_forwarddiff_solve` with a LinearSolve-routed solve. On 2.35.0 a rank-deficient nested FIRK stage Jacobian throws `LinearAlgebra.SingularException` out of that backslash; on 2.36.0+ LinearSolve's default falls back from the failed LU to pivoted QR and the solve completes.

This widens the entry to `"4.2, 5"` and bumps the patch version. LinearSolve is an unused test dependency (no `.jl` file under `lib/BoundaryValueDiffEqFIRK/` references it), so the compat entry's only effect is on resolution.

`lib/BoundaryValueDiffEqMIRK/Project.toml` carries the identical pin, but widening it is **deliberately not included here** — see "Not verified" below.

Supersedes #615, which worked around the same exception by stripping ForwardDiff duals from the nested stage parameters. That zeroes `∂K/∂yᵢ` in the outer collocation Jacobian rather than fixing the singular solve; see https://github.com/SciML/BoundaryValueDiffEq.jl/pull/615#issuecomment-5471453050.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

### Resolution: before vs. after

The FIRK test environment was reconstructed the way `Pkg.test` builds it (package deps + test-target extras, with the package's `[compat]` applied) and resolved on each side of the change:

```
=== BoundaryValueDiffEqFIRK before (LinearSolve = "4.2")
LinearSolve               4.3.0
NonlinearSolveBase        2.35.0
NonlinearSolveFirstOrder  2.2.0
SciMLBase                 3.39.1
=== BoundaryValueDiffEqFIRK after (LinearSolve = "4.2, 5")
LinearSolve               5.15.1
NonlinearSolveBase        2.49.1
NonlinearSolveFirstOrder  2.5.0
SciMLBase                 3.50.1
```

The "before" column reproduces exactly what CI resolved in the failing job (`↓ LinearSolve v5.13.2 ⇒ v4.3.0`, `↓ NonlinearSolveBase v2.48.0 ⇒ v2.35.0`, `↓ NonlinearSolveFirstOrder v2.4.1 ⇒ v2.2.0`, `↓ SciMLBase v3.49.2 ⇒ v3.39.1`): https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/33100708886/job/98621904890

### Failing before

Under the capped resolution, the underconstrained nested solves throw. From the CI job above:

```
Solver: LobattoIIIa4 with NewtonRaphson: Error During Test at .../nested/nlls_underconstrained_tests.jl:15
  Got exception outside of a @test
  LinearAlgebra.SingularException(72)
  Stacktrace:
    [1] checknonsingular
      @ .../LinearAlgebra/src/factorization.jl:69 [inlined]
    ...
    [9] \(A::Matrix{Float64}, B::Matrix{Float64})
   [10] nonlinearsolve_forwarddiff_solve(...)
      @ NonlinearSolveBase .../NonlinearSolveBase/yoCxi/ext/NonlinearSolveBaseForwardDiffExt.jl:181
```

`yoCxi` is NonlinearSolveBase v2.35.0; line 181 there is `z = -Jᵤ \ Jₚ`. 72 = 18 states x 4 stages (LobattoIIIa4); the RadauIIa5 case reports `SingularException(90)` = 18 x 5.

### Passing after

The three combinations that throw under the capped resolution, run against **unmodified `master` source** with the uncapped dependency set (NonlinearSolveBase 2.49.1, LinearSolve 5.15.1) — i.e. no source change, only the resolution this PR unblocks:

```
NonlinearSolveBase LinearSolve ext loaded: true
=== LobattoIIIa4/NewtonRaphson/prob1
   retcode = Success
   elapsed = 1432.879947185 s
=== LobattoIIIa4/GaussNewton/prob1
   retcode = Success
   elapsed = 1378.711505451 s
=== RadauIIa5/NewtonRaphson/prob1
   retcode = Success
   elapsed = 192.780172371 s
```

### Test groups

```
BOUNDARYVALUEDIFFEQ_TEST_GROUP=QA julia --project=lib/BoundaryValueDiffEqFIRK -e 'using Pkg; Pkg.test()'
  Test Summary:     | Pass  Total     Time
  Quality Assurance |   84     84  1m30.8s
       Testing BoundaryValueDiffEqFIRK tests passed

BOUNDARYVALUEDIFFEQ_TEST_GROUP=PUBLIC_FACADE julia --project=lib/BoundaryValueDiffEqFIRK -e 'using Pkg; Pkg.test()'
       Testing BoundaryValueDiffEqFIRK tests passed
```

### Format and spelling

```
runic --check --diff .   -> exit 0
typos .                  -> exit 0
git diff --check         -> clean
```

## Not verified

- `NESTED_NLLS_UNDERCONSTRAINED`, the group that actually failed, is still running locally — the file itself notes individual solves take 4-20 minutes and the 22 cases run for hours. The three combinations that threw are covered by the targeted run above; the full group's result will be posted as a comment when it finishes, and CI runs it regardless. No other FIRK group was run locally.
- Downstream, GPU, and prerelease jobs were not run locally.
- **MIRK is intentionally left pinned.** The same widening applied to `lib/BoundaryValueDiffEqMIRK/Project.toml` makes its `Core` group fail:
  ```
  VectorOfVector Initial Condition: Test Failed at lib/BoundaryValueDiffEqMIRK/test/Core/vectorofvector_initials_tests.jl:78
    Expression: SciMLBase.successful_retcode(sol6.retcode)
  Test Summary:                      | Pass  Fail  Total     Time
  MIRK VectorOfVector Initials Tests |    1     1      2  1m16.5s
  ```
  That is `MIRK6` at `dt = 0.1, abstol = 1e-15`, and the job is green on master CI under the 4.x pin. Whatever changed between LinearSolve 4.3/NonlinearSolveBase 2.35 and LinearSolve 5.15/NonlinearSolveBase 2.49 for that solve needs its own investigation; it is not bundled into this PR and no test was loosened to accommodate it.
- The root `Project.toml` already allows `LinearSolve = "4, 5"`; no other sublibrary Project.toml was touched.

## For a reviewer to push back on

- LinearSolve is an unused test dependency. Removing it from `[extras]`/`[targets]` entirely would be the stronger fix; widening the bound is the smaller one.
- The patch version bump assumes compat widening is non-breaking for the sublibrary itself, which it is — the entry only applies to its test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.251)
https://claude.ai/code/session_01GHa2ZK4kgnGknJBGoM2sV8
