### PR TITLE
Add 32-bit Misc CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -13,6 +13,12 @@
 [Misc]
 versions = ["lts", "1", "pre"]
 
+["Misc 32-bit"]
+group = "Misc"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [Wrappers]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION

## Summary
- Add a `["Misc 32-bit"]` matrix-only alias (`group = "Misc"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `Misc` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
