### PR TITLE
Require LatticeRules 0.0.2 (32-bit LatticeRule32)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ ODEInterface = "54ca160b-1b9f-5127-a996-1867f4bc2a2c"
 BoundaryValueDiffEqODEInterfaceExt = "ODEInterface"
 
 [compat]
+LatticeRules = "0.0.2"
 ADTypes = "1.14"
 BoundaryValueDiffEqAscher = "1.16.0"
 BoundaryValueDiffEqCore = "2.8.1"
@@ -68,6 +69,7 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -86,4 +88,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqDevTools", "DifferentiationInterface", "LinearSolve", "NonlinearSolveFirstOrder", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqTsit5", "Pkg", "Random", "RecursiveArrayTools", "SafeTestsets", "SciMLTesting", "Sparspak", "StaticArrays", "Test", "OptimizationBase", "NonlinearSolveBase"]
+test = ["LatticeRules", "DiffEqDevTools", "DifferentiationInterface", "LinearSolve", "NonlinearSolveFirstOrder", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqTsit5", "Pkg", "Random", "RecursiveArrayTools", "SafeTestsets", "SciMLTesting", "Sparspak", "StaticArrays", "Test", "OptimizationBase", "NonlinearSolveBase"]


### PR DESCRIPTION
## Summary
Force LatticeRules ≥0.0.2 for QuasiMonteCarlo LatticeRuleSample on i686.

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)